### PR TITLE
feat: support namespace re-export in TypeScript observe (#85)

### DIFF
--- a/crates/core/src/observe.rs
+++ b/crates/core/src/observe.rs
@@ -41,6 +41,10 @@ pub struct BarrelReExport {
     pub symbols: Vec<String>,
     pub from_specifier: String,
     pub wildcard: bool,
+    /// True when this is a namespace re-export (`export * as Ns from '...'`).
+    /// The namespace name changes the symbol space, so nested resolution must
+    /// treat this as an opaque wildcard (symbols dropped on recursion).
+    pub namespace_wildcard: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -273,10 +277,18 @@ fn resolve_barrel_exports_inner(
             resolve_import_path(ext, &re_export.from_specifier, barrel_path, scan_root)
         {
             if ext.is_barrel_file(&resolved_str) {
+                // Namespace re-export (`export * as Ns from '...'`) changes the symbol
+                // namespace, so the caller's symbol names no longer match the nested
+                // exports. Treat as opaque wildcard by passing empty symbols.
+                let nested_symbols: &[String] = if re_export.namespace_wildcard {
+                    &[]
+                } else {
+                    symbols
+                };
                 resolve_barrel_exports_inner(
                     ext,
                     &PathBuf::from(&resolved_str),
-                    symbols,
+                    nested_symbols,
                     scan_root,
                     canonical_root,
                     visited,
@@ -284,6 +296,8 @@ fn resolve_barrel_exports_inner(
                     results,
                 );
             } else if !ext.is_non_sut_helper(&resolved_str, false) {
+                // Non-barrel path: namespace_wildcard does not change symbols filtering here.
+                // The caller's symbols are used as-is for file_exports_any_symbol check.
                 if !symbols.is_empty()
                     && re_export.wildcard
                     && !ext.file_exports_any_symbol(Path::new(&resolved_str), symbols)

--- a/crates/lang-python/src/observe.rs
+++ b/crates/lang-python/src/observe.rs
@@ -367,6 +367,7 @@ impl ObserveExtractor for PythonExtractor {
                 symbols,
                 from_specifier,
                 wildcard: false,
+                namespace_wildcard: false,
             })
             .collect()
     }

--- a/crates/lang-rust/src/observe.rs
+++ b/crates/lang-rust/src/observe.rs
@@ -298,6 +298,7 @@ impl ObserveExtractor for RustExtractor {
                             symbols: Vec::new(),
                             from_specifier: format!("./{mod_name}"),
                             wildcard: true,
+                            namespace_wildcard: false,
                         });
                     }
                 }
@@ -583,6 +584,7 @@ fn extract_pub_use_re_exports(
             symbols: Vec::new(),
             from_specifier: format!("./{}", module_part.replace("::", "/")),
             wildcard: true,
+            namespace_wildcard: false,
         });
         return;
     }
@@ -601,6 +603,7 @@ fn extract_pub_use_re_exports(
                 symbols,
                 from_specifier: format!("./{}", module_part.replace("::", "/")),
                 wildcard: false,
+                namespace_wildcard: false,
             });
         }
         return;
@@ -615,6 +618,7 @@ fn extract_pub_use_re_exports(
             symbols: vec![symbol.to_string()],
             from_specifier: format!("./{}", module_parts.join("/")),
             wildcard: false,
+            namespace_wildcard: false,
         });
     }
 }

--- a/crates/lang-typescript/queries/re_export.scm
+++ b/crates/lang-typescript/queries/re_export.scm
@@ -11,3 +11,9 @@
   "*" @wildcard
   source: (string
     (string_fragment) @from_specifier))
+
+;; Namespace re-export: export * as Ns from './module'
+(export_statement
+  (namespace_export) @ns_wildcard
+  source: (string
+    (string_fragment) @from_specifier))

--- a/crates/lang-typescript/src/observe.rs
+++ b/crates/lang-typescript/src/observe.rs
@@ -776,6 +776,7 @@ impl TypeScriptExtractor {
 
         let symbol_idx = query.capture_index_for_name("symbol_name");
         let wildcard_idx = query.capture_index_for_name("wildcard");
+        let ns_wildcard_idx = query.capture_index_for_name("ns_wildcard");
         let specifier_idx = query
             .capture_index_for_name("from_specifier")
             .expect("@from_specifier capture not found in re_export.scm");
@@ -789,6 +790,7 @@ impl TypeScriptExtractor {
         struct ReExportEntry {
             symbols: Vec<String>,
             wildcard: bool,
+            namespace_wildcard: bool,
         }
         let mut grouped: HashMap<String, ReExportEntry> = HashMap::new();
 
@@ -796,9 +798,13 @@ impl TypeScriptExtractor {
             let mut from_spec = None;
             let mut sym_name = None;
             let mut is_wildcard = false;
+            let mut is_ns_wildcard = false;
 
             for cap in m.captures {
-                if wildcard_idx == Some(cap.index) {
+                if ns_wildcard_idx == Some(cap.index) {
+                    is_wildcard = true;
+                    is_ns_wildcard = true;
+                } else if wildcard_idx == Some(cap.index) {
                     is_wildcard = true;
                 } else if cap.index == specifier_idx {
                     from_spec = Some(cap.node.utf8_text(source_bytes).unwrap_or("").to_string());
@@ -812,9 +818,13 @@ impl TypeScriptExtractor {
             let entry = grouped.entry(spec).or_insert(ReExportEntry {
                 symbols: Vec::new(),
                 wildcard: false,
+                namespace_wildcard: false,
             });
             if is_wildcard {
                 entry.wildcard = true;
+            }
+            if is_ns_wildcard {
+                entry.namespace_wildcard = true;
             }
             if let Some(sym) = sym_name {
                 if !sym.is_empty() && !entry.symbols.contains(&sym) {
@@ -829,6 +839,7 @@ impl TypeScriptExtractor {
                 symbols: entry.symbols,
                 from_specifier: from_spec,
                 wildcard: entry.wildcard,
+                namespace_wildcard: entry.namespace_wildcard,
             })
             .collect()
     }
@@ -2928,12 +2939,13 @@ describe('UsersController', () => {});
     }
 
     // === Boundary Specification Tests (B1-B6) ===
-    // These tests document CURRENT behavior at failure boundaries.
-    // All assertions reflect known limitations, not desired future behavior.
+    // These tests document behavior at failure boundaries.
+    // B1: Fixed — namespace re-export is now captured as wildcard.
+    // B2-B6: Assertions reflect known limitations (not desired future behavior).
 
-    // TC-01: Boundary B1 — namespace re-export is NOT captured by extract_barrel_re_exports
+    // TC-01: Boundary B1 — namespace re-export captured as wildcard=true (B1 fix applied)
     #[test]
-    fn boundary_b1_ns_reexport_not_captured() {
+    fn boundary_b1_ns_reexport_captured_as_wildcard() {
         // Given: barrel index.ts with `export * as Ns from './validators'`
         let source = "export * as Validators from './validators';";
         let extractor = TypeScriptExtractor::new();
@@ -2941,13 +2953,19 @@ describe('UsersController', () => {});
         // When: extract_barrel_re_exports
         let re_exports = extractor.extract_barrel_re_exports(source, "index.ts");
 
-        // Then: namespace re-export is NOT captured (empty vec)
-        // Note: re_export.scm only handles `export { X } from` and `export * from`,
-        //       not `export * as Ns from` (namespace export is a different AST node)
-        assert!(
-            re_exports.is_empty(),
-            "expected empty re_exports for namespace export, got {:?}",
+        // Then: namespace re-export IS captured as wildcard=true (B1 fix applied)
+        assert_eq!(
+            re_exports.len(),
+            1,
+            "expected 1 re-export for namespace export, got {:?}",
             re_exports
+        );
+        let re = &re_exports[0];
+        assert_eq!(re.from_specifier, "./validators");
+        assert!(
+            re.wildcard,
+            "expected wildcard=true for namespace re-export, got {:?}",
+            re
         );
     }
 
@@ -3006,14 +3024,20 @@ describe('UsersController', () => {});
         let mappings =
             extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
 
-        // Then: foo.service.ts has NO test_files (FN — namespace re-export not resolved)
-        // Layer 1 (filename convention) produces no match either, so the mapping has no test_files.
-        let all_test_files: Vec<&String> =
-            mappings.iter().flat_map(|m| m.test_files.iter()).collect();
+        // Then: foo.service.ts IS mapped to foo.spec.ts (B1 fix: namespace re-export resolved)
+        let prod_mapping = mappings
+            .iter()
+            .find(|m| m.production_file.contains("foo.service.ts"));
         assert!(
-            all_test_files.is_empty(),
-            "expected no test_files mapped (FN: namespace re-export not resolved), got {:?}",
-            all_test_files
+            prod_mapping.is_some(),
+            "expected foo.service.ts to appear in mappings, got {:?}",
+            mappings
+        );
+        let mapping = prod_mapping.unwrap();
+        assert!(
+            !mapping.test_files.is_empty(),
+            "expected foo.service.ts to have test_files (Layer 2 via namespace re-export), got {:?}",
+            mapping
         );
     }
 
@@ -3696,6 +3720,216 @@ describe('Mixed', () => {});
             all_test_files.is_empty(),
             "expected no test_files (import target outside scan_root), got {:?}",
             all_test_files
+        );
+    }
+
+    // === B1 namespace re-export fix tests (TS-B1-NS-01 to TS-B1-NS-04) ===
+
+    // TS-B1-NS-01: namespace re-export が wildcard として抽出される
+    #[test]
+    fn test_b1_ns_reexport_extracted_as_wildcard() {
+        // Given: `export * as Validators from './validators';`
+        let source = "export * as Validators from './validators';";
+        let extractor = TypeScriptExtractor::new();
+
+        // When: extract_barrel_re_exports
+        let re_exports = extractor.extract_barrel_re_exports(source, "index.ts");
+
+        // Then: 1件返る: from_specifier="./validators", wildcard=true
+        assert_eq!(
+            re_exports.len(),
+            1,
+            "expected 1 re-export, got {:?}",
+            re_exports
+        );
+        let re = &re_exports[0];
+        assert_eq!(re.from_specifier, "./validators");
+        assert!(
+            re.wildcard,
+            "expected wildcard=true for `export * as Ns from`, got {:?}",
+            re
+        );
+    }
+
+    // TS-B1-NS-02: namespace re-export 経由の mapping が TP になる
+    #[test]
+    fn test_b1_ns_reexport_mapping_resolves_via_layer2() {
+        use tempfile::TempDir;
+
+        // Given:
+        //   validators/foo.service.ts (production)
+        //   index.ts: `export * as Ns from './validators'`
+        //   validators/index.ts: `export { FooService } from './foo.service'`
+        //   test/foo.spec.ts: `import { Ns } from '../index'`
+        let dir = TempDir::new().unwrap();
+        let validators_dir = dir.path().join("validators");
+        let test_dir = dir.path().join("test");
+        std::fs::create_dir_all(&validators_dir).unwrap();
+        std::fs::create_dir_all(&test_dir).unwrap();
+
+        let prod_path = validators_dir.join("foo.service.ts");
+        std::fs::File::create(&prod_path).unwrap();
+
+        std::fs::write(
+            dir.path().join("index.ts"),
+            "export * as Ns from './validators';",
+        )
+        .unwrap();
+        std::fs::write(
+            validators_dir.join("index.ts"),
+            "export { FooService } from './foo.service';",
+        )
+        .unwrap();
+
+        let test_path = test_dir.join("foo.spec.ts");
+        std::fs::write(
+            &test_path,
+            "import { Ns } from '../index';\ndescribe('FooService', () => {});",
+        )
+        .unwrap();
+
+        let production_files = vec![prod_path.to_string_lossy().into_owned()];
+        let mut test_sources = HashMap::new();
+        test_sources.insert(
+            test_path.to_string_lossy().into_owned(),
+            std::fs::read_to_string(&test_path).unwrap(),
+        );
+
+        let extractor = TypeScriptExtractor::new();
+
+        // When: map_test_files_with_imports
+        let mappings =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+
+        // Then: foo.service.ts が test_files にマッチ (Layer 2 via namespace re-export)
+        let prod_mapping = mappings
+            .iter()
+            .find(|m| m.production_file.contains("foo.service.ts"));
+        assert!(
+            prod_mapping.is_some(),
+            "expected foo.service.ts in mappings, got {:?}",
+            mappings
+        );
+        let mapping = prod_mapping.unwrap();
+        assert!(
+            !mapping.test_files.is_empty(),
+            "expected foo.service.ts mapped to foo.spec.ts via namespace re-export, got {:?}",
+            mapping
+        );
+        assert!(
+            mapping.test_files.iter().any(|f| f.contains("foo.spec.ts")),
+            "expected foo.spec.ts in test_files, got {:?}",
+            mapping.test_files
+        );
+    }
+
+    // TS-B1-NS-03: 通常の wildcard と namespace re-export の混在
+    #[test]
+    fn test_b1_ns_reexport_mixed_with_plain_wildcard() {
+        // Given: `export * from './a'; export * as B from './b';`
+        let source = "export * from './a';\nexport * as B from './b';";
+        let extractor = TypeScriptExtractor::new();
+
+        // When: extract_barrel_re_exports
+        let mut re_exports = extractor.extract_barrel_re_exports(source, "index.ts");
+
+        // Then: 2件返る: 両方 wildcard=true
+        assert_eq!(
+            re_exports.len(),
+            2,
+            "expected 2 re-exports, got {:?}",
+            re_exports
+        );
+
+        re_exports.sort_by(|a, b| a.from_specifier.cmp(&b.from_specifier));
+
+        let re_a = re_exports.iter().find(|r| r.from_specifier == "./a");
+        let re_b = re_exports.iter().find(|r| r.from_specifier == "./b");
+
+        assert!(
+            re_a.is_some(),
+            "expected re-export from './a', got {:?}",
+            re_exports
+        );
+        assert!(
+            re_b.is_some(),
+            "expected re-export from './b', got {:?}",
+            re_exports
+        );
+        let a = re_a.unwrap();
+        let b = re_b.unwrap();
+        assert!(
+            a.wildcard,
+            "expected wildcard=true for plain `export * from './a'`, got {:?}",
+            a
+        );
+        assert!(
+            !a.namespace_wildcard,
+            "expected namespace_wildcard=false for plain wildcard, got {:?}",
+            a
+        );
+        assert!(
+            b.wildcard,
+            "expected wildcard=true for namespace `export * as B from './b'`, got {:?}",
+            b
+        );
+        assert!(
+            b.namespace_wildcard,
+            "expected namespace_wildcard=true for namespace re-export, got {:?}",
+            b
+        );
+    }
+
+    // TS-B1-NS-04: named re-export との混在
+    #[test]
+    fn test_b1_ns_reexport_mixed_with_named_reexport() {
+        // Given: `export { Foo } from './a'; export * as B from './b';`
+        let source = "export { Foo } from './a';\nexport * as B from './b';";
+        let extractor = TypeScriptExtractor::new();
+
+        // When: extract_barrel_re_exports
+        let re_exports = extractor.extract_barrel_re_exports(source, "index.ts");
+
+        // Then: 2件: a は symbols=["Foo"], b は wildcard=true
+        assert_eq!(
+            re_exports.len(),
+            2,
+            "expected 2 re-exports, got {:?}",
+            re_exports
+        );
+
+        let re_a = re_exports.iter().find(|r| r.from_specifier == "./a");
+        let re_b = re_exports.iter().find(|r| r.from_specifier == "./b");
+
+        assert!(
+            re_a.is_some(),
+            "expected re-export from './a', got {:?}",
+            re_exports
+        );
+        assert!(
+            re_b.is_some(),
+            "expected re-export from './b', got {:?}",
+            re_exports
+        );
+
+        let re_a = re_a.unwrap();
+        assert!(
+            !re_a.wildcard,
+            "expected wildcard=false for named re-export from './a', got {:?}",
+            re_a
+        );
+        assert_eq!(
+            re_a.symbols,
+            vec!["Foo".to_string()],
+            "expected symbols=[\"Foo\"] for './a', got {:?}",
+            re_a.symbols
+        );
+
+        let re_b = re_b.unwrap();
+        assert!(
+            re_b.wildcard,
+            "expected wildcard=true for namespace re-export from './b', got {:?}",
+            re_b
         );
     }
 }

--- a/docs/cycles/20260318_0844_ts-observe-namespace-reexport.md
+++ b/docs/cycles/20260318_0844_ts-observe-namespace-reexport.md
@@ -1,0 +1,153 @@
+---
+feature: "B1 — TypeScript observe: namespace re-export support"
+cycle: "20260318_0844"
+phase: COMMIT
+complexity: trivial
+test_count: 4
+risk_level: low
+codex_session_id: ""
+created: 2026-03-18 08:44
+updated: 2026-03-18 08:44
+---
+
+# Cycle: B1 — TypeScript observe: namespace re-export support
+
+## Scope Definition
+
+### In Scope
+- [ ] `crates/lang-typescript/queries/re_export.scm` — namespace_export パターン追加
+- [ ] `crates/lang-typescript/src/observe.rs` — `extract_barrel_re_exports_impl` で `ns_wildcard` capture を処理
+- [ ] 境界テスト期待値の反転
+
+### Out of Scope
+- 他言語 observe への影響
+- named re-export の挙動変更
+- TypeScript 以外の barrel resolution 変更
+- Ns.Foo -> Foo の namespace 解決 (opaque wildcard として扱う)
+
+### Files to Change (target: 10 or less)
+- `crates/lang-typescript/queries/re_export.scm` (edit)
+- `crates/lang-typescript/src/observe.rs` (edit)
+
+## Environment
+
+### Scope
+- Layer: Backend (`crates/lang-typescript` のみ)
+- Plugin: dev-crew:rust-quality (cargo test / clippy / fmt)
+- Risk: 20/100 (PASS)
+
+### Runtime
+- Language: Rust (cargo test)
+
+### Dependencies (key packages)
+- tree-sitter: 既存
+- tree-sitter-typescript: 既存
+
+### Risk Interview (BLOCK only)
+
+(BLOCK なし — リスク 20/100)
+
+## Context & Dependencies
+
+### Reference Documents
+- `crates/lang-typescript/queries/re_export.scm` — 既存 re-export クエリ
+- `crates/lang-typescript/src/observe.rs` L764-834 — `extract_barrel_re_exports_impl` 実装
+- `crates/lang-typescript/src/observe.rs` L2934-3018 — 境界テスト
+
+### Dependent Features
+- TypeScript observe barrel resolution: `crates/lang-typescript/src/observe.rs`
+- Wildcard re-export processing: 既存 wildcard パスを再利用
+
+### Related Issues/PRs
+- (none)
+
+## Test List
+
+### TODO
+(none)
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+- [x] TS-B1-NS-01: namespace re-export が wildcard として抽出される
+- [x] TS-B1-NS-02: namespace re-export 経由の mapping が TP になる
+- [x] TS-B1-NS-03: 通常の wildcard と namespace re-export の混在 (namespace_wildcard フラグ差異も検証)
+- [x] TS-B1-NS-04: named re-export との混在
+- [x] TC-01: boundary_b1_ns_reexport_captured_as_wildcard (反転)
+- [x] TC-02: boundary_b1_ns_reexport_mapping_miss (反転)
+
+## Implementation Notes
+
+### Goal
+TypeScript observe の Recall 93.4% (NestJS) をさらに改善する。`export * as Ns from './module'` が `re_export.scm` に未対応で、barrel resolution で見落とされる boundary (B1) を修正する。
+
+### Background
+NestJS eval では B1 単体の FN 件数は少ないが、namespace re-export パターンは utility package で頻出するため汎用性が高い。
+
+`export * as Validators from './validators'` のAST:
+
+```
+(export_statement
+  (namespace_export
+    (identifier))          ; "Validators"
+  source: (string
+    (string_fragment)))    ; "./validators"
+```
+
+### Design Approach
+`export * as Ns from './module'` を `wildcard: true` の BarrelReExport として扱う。
+
+**Step 1**: `re_export.scm` に namespace_export パターンを追加:
+
+```scheme
+;; Namespace re-export: export * as Ns from './module'
+(export_statement
+  (namespace_export) @ns_wildcard
+  source: (string
+    (string_fragment) @from_specifier))
+```
+
+**Step 2**: `observe.rs` の `extract_barrel_re_exports_impl` に `ns_wildcard` capture index を追加。既存の `wildcard_idx` チェック (L801) に `|| ns_wildcard_idx == Some(cap.index)` で合算する。barrel resolution は既存コードが `wildcard=true` の BarrelReExport を透過的に処理するため変更不要。
+
+**設計判断**: namespace は opaque wildcard として扱う (Ns.Foo -> Foo の静的解決は行わない)。wildcard=true により `./module` 内の全 public シンボルが解決対象になり FN を回避する。FP リスクは低い (barrel 経由の precision 99.4%)。
+
+**Step 3**: 境界テスト反転 (L2934-3018)。
+
+## Progress Log
+
+### 2026-03-18 08:44 - INIT
+- Cycle doc created
+- Scope definition ready
+
+### 2026-03-18 - RED
+- 境界テスト2件反転 (boundary_b1_ns_reexport_captured_as_wildcard, boundary_b1_ns_reexport_mapping_miss)
+- 新規テスト4件追加 (TS-B1-NS-01〜04)
+- 6テスト全て失敗確認 (RED state)
+
+### 2026-03-18 - GREEN
+- re_export.scm に namespace_export パターン追加
+- observe.rs に ns_wildcard capture 処理追加
+- core BarrelReExport に namespace_wildcard フィールド追加
+- barrel resolution で namespace_wildcard 時に symbols を空にして再帰
+- 946テスト全通過
+
+### 2026-03-18 - REVIEW
+- correctness-reviewer: score 42 (PASS)
+- 指摘3件修正: テスト名改名、namespace_wildcard assert追加、非バレルパスのコメント追加
+- self-dogfooding: BLOCK 0 | WARN 0 | INFO 7 | PASS 9
+
+---
+
+## Next Steps
+
+1. [Done] INIT
+2. [Done] PLAN
+3. [Done] RED
+4. [Done] GREEN
+5. [Done] REFACTOR (不要と判断)
+6. [Done] REVIEW
+7. [Next] COMMIT

--- a/docs/observe-boundaries.md
+++ b/docs/observe-boundaries.md
@@ -25,9 +25,9 @@ Namespace re-export (`export * as Ns from`) produces a `namespace_export` AST no
 
 **Impact**: When a barrel file uses namespace grouping, all symbols behind that namespace become invisible to import tracing. This is uncommon in NestJS but appears in some utility packages.
 
-**Tests**: `boundary_b1_ns_reexport_not_captured`, `boundary_b1_ns_reexport_mapping_miss`
+**Tests**: `boundary_b1_ns_reexport_captured_as_wildcard`, `boundary_b1_ns_reexport_mapping_miss` (both inverted to TP after fix)
 
-**Fix path**: Add a third pattern to `re_export.scm` targeting `namespace_export` nodes. Requires deciding whether to resolve the namespace (Ns.Foo -> Foo) or treat the entire namespace as an opaque symbol.
+**Fix path**: Add a third pattern to `re_export.scm` targeting `namespace_export` nodes. **Decision**: Treat as opaque wildcard (`wildcard: true`). Ns.Foo -> Foo resolution is out of scope — wildcard covers all public symbols in the target module, avoiding FN with minimal FP risk (barrel precision 99.4%).
 
 ## B2: Cross-package barrel import (non-relative path)
 


### PR DESCRIPTION
## Summary
- `export * as Ns from './module'` を `re_export.scm` の新パターンで検出し、`wildcard: true` の BarrelReExport として barrel resolution に統合
- B1 boundary (namespace re-export) による FN を解消
- 境界テスト2件反転 + 新規テスト4件追加 (946テスト全通過、BLOCK 0)

## Test plan
- [x] `cargo test` — 946 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — 0 errors
- [x] `cargo fmt --check` — 差分なし
- [x] `cargo run -- --lang rust .` — BLOCK 0 | WARN 0 | INFO 7 | PASS 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)