### PR TITLE
feat: resolve monorepo cross-package imports via node_modules symlink (B2)

### DIFF
--- a/crates/lang-typescript/src/observe.rs
+++ b/crates/lang-typescript/src/observe.rs
@@ -889,6 +889,9 @@ impl TypeScriptExtractor {
                     })
             });
 
+        // Cache for node_modules symlink resolution (shared across all test files)
+        let mut nm_symlink_cache: HashMap<String, Option<PathBuf>> = HashMap::new();
+
         // Layer 2: import tracing for all test files (Layer 1 matched tests may
         // also import other production files not matched by filename convention)
         for (test_file, source) in test_sources {
@@ -938,11 +941,13 @@ impl TypeScriptExtractor {
                 }
             }
 
+            // Extract non-relative specifiers once (used by Layer 2b and 2c)
+            let all_specifiers =
+                <Self as ObserveExtractor>::extract_all_import_specifiers(self, source);
+
             // Layer 2b: tsconfig alias resolution
             if let Some(ref tc_paths) = tsconfig_paths {
-                let alias_imports =
-                    <Self as ObserveExtractor>::extract_all_import_specifiers(self, source);
-                for (specifier, symbols) in &alias_imports {
+                for (specifier, symbols) in &all_specifiers {
                     let Some(alias_base) = tc_paths.resolve_alias(specifier) else {
                         continue;
                     };
@@ -950,6 +955,30 @@ impl TypeScriptExtractor {
                         resolve_absolute_base_to_file(self, &alias_base, &canonical_root)
                     {
                         collect_matches(&resolved, symbols, &mut matched_indices);
+                    }
+                }
+            }
+
+            // Layer 2c: node_modules symlink resolution (monorepo cross-package)
+            // Follow yarn/pnpm workspace symlinks in node_modules to resolve
+            // cross-package imports that are not covered by tsconfig aliases.
+            for (specifier, symbols) in &all_specifiers {
+                // Skip if already resolved by tsconfig alias (Layer 2b)
+                if let Some(ref tc_paths) = tsconfig_paths {
+                    if tc_paths.resolve_alias(specifier).is_some() {
+                        continue;
+                    }
+                }
+                if let Some(resolved_dir) =
+                    resolve_node_modules_symlink(specifier, &canonical_root, &mut nm_symlink_cache)
+                {
+                    // The symlink points to a package root directory (e.g., packages/common).
+                    // Find all production files that are under this resolved directory.
+                    let resolved_dir_str = resolved_dir.to_string_lossy().into_owned();
+                    for prod_canonical in canonical_to_idx.keys() {
+                        if prod_canonical.starts_with(&resolved_dir_str) {
+                            collect_matches(prod_canonical, symbols, &mut matched_indices);
+                        }
                     }
                 }
             }
@@ -976,6 +1005,37 @@ impl TypeScriptExtractor {
 
         mappings
     }
+}
+
+/// Resolve a non-relative specifier by following node_modules symlinks.
+///
+/// In yarn/pnpm workspaces, cross-package dependencies are installed as symlinks:
+///   scan_root/node_modules/@org/common -> ../../packages/common
+///
+/// This function:
+/// 1. Checks cache first (same specifier is reused across test files)
+/// 2. Builds the path scan_root/node_modules/{specifier}
+/// 3. Returns Some(canonical_path) only if that path is a symlink (not a real dir)
+/// 4. Returns None for real directories (npm install), missing paths, or errors
+///
+/// Only enabled on Unix (symlink creation requires Unix APIs in tests).
+fn resolve_node_modules_symlink(
+    specifier: &str,
+    scan_root: &Path,
+    cache: &mut HashMap<String, Option<PathBuf>>,
+) -> Option<PathBuf> {
+    if let Some(cached) = cache.get(specifier) {
+        return cached.clone();
+    }
+
+    let candidate = scan_root.join("node_modules").join(specifier);
+    let result = match std::fs::symlink_metadata(&candidate) {
+        Ok(meta) if meta.file_type().is_symlink() => candidate.canonicalize().ok(),
+        _ => None,
+    };
+
+    cache.insert(specifier.to_string(), result.clone());
+    result
 }
 
 /// Resolve a module specifier to an absolute file path.
@@ -3059,29 +3119,46 @@ describe('UsersController', () => {});
         );
     }
 
-    // TC-04: Boundary B2 — cross-package barrel import is unresolvable (FN)
+    // TC-04: Boundary B2 — cross-package symlink import is resolved via node_modules symlink (TP)
+    // Formerly "boundary_b2_cross_pkg_barrel_unresolvable" (was asserting FN; now asserts TP after B2 fix)
+    #[cfg(unix)]
     #[test]
-    fn boundary_b2_cross_pkg_barrel_unresolvable() {
+    fn boundary_b2_cross_pkg_symlink_resolved() {
+        use std::os::unix::fs::symlink;
         use tempfile::TempDir;
 
         // Given:
+        //   packages/common/src/foo.ts (production, cross-package file)
         //   packages/core/ (scan_root)
-        //   packages/core/src/foo.service.ts (production)
-        //   packages/common/src/foo.ts (production, in different package)
-        //   packages/core/test/foo.spec.ts: `import { Foo } from '@org/common'` (non-relative)
+        //   packages/core/src/foo.service.ts (local production)
+        //   packages/core/node_modules/@org/common -> ../../common (symlink)
+        //   packages/core/test/foo.spec.ts: `import { Foo } from '@org/common'`
+        //   production_files contains BOTH foo.service.ts AND packages/common/src/foo.ts
         let dir = TempDir::new().unwrap();
         let core_src = dir.path().join("packages").join("core").join("src");
         let core_test = dir.path().join("packages").join("core").join("test");
+        let core_nm_org = dir
+            .path()
+            .join("packages")
+            .join("core")
+            .join("node_modules")
+            .join("@org");
         let common_src = dir.path().join("packages").join("common").join("src");
         std::fs::create_dir_all(&core_src).unwrap();
         std::fs::create_dir_all(&core_test).unwrap();
+        std::fs::create_dir_all(&core_nm_org).unwrap();
         std::fs::create_dir_all(&common_src).unwrap();
 
-        let prod_path = core_src.join("foo.service.ts");
-        std::fs::File::create(&prod_path).unwrap();
+        let local_prod_path = core_src.join("foo.service.ts");
+        std::fs::File::create(&local_prod_path).unwrap();
 
         let common_path = common_src.join("foo.ts");
         std::fs::File::create(&common_path).unwrap();
+
+        // Create symlink: packages/core/node_modules/@org/common -> ../../common
+        let symlink_path = core_nm_org.join("common");
+        let target = dir.path().join("packages").join("common");
+        symlink(&target, &symlink_path).unwrap();
 
         let test_path = core_test.join("foo.spec.ts");
         std::fs::write(
@@ -3091,7 +3168,11 @@ describe('UsersController', () => {});
         .unwrap();
 
         let scan_root = dir.path().join("packages").join("core");
-        let production_files = vec![prod_path.to_string_lossy().into_owned()];
+        // production_files contains cross-package file (common/src/foo.ts)
+        let production_files = vec![
+            local_prod_path.to_string_lossy().into_owned(),
+            common_path.to_string_lossy().into_owned(),
+        ];
         let mut test_sources = HashMap::new();
         test_sources.insert(
             test_path.to_string_lossy().into_owned(),
@@ -3104,14 +3185,275 @@ describe('UsersController', () => {});
         let mappings =
             extractor.map_test_files_with_imports(&production_files, &test_sources, &scan_root);
 
-        // Then: packages/common/src/foo.ts has NO test_files (cross-package import not resolved)
-        // Since `@org/common` is non-relative, extract_imports will skip it entirely.
-        let all_test_files: Vec<&String> =
-            mappings.iter().flat_map(|m| m.test_files.iter()).collect();
+        // Then: packages/common/src/foo.ts IS mapped (symlink resolved via Layer 2c)
+        let common_path_str = common_path.to_string_lossy().into_owned();
+        let common_mapping = mappings
+            .iter()
+            .find(|m| m.production_file == common_path_str);
         assert!(
-            all_test_files.is_empty(),
-            "expected no test_files mapped (FN: cross-package import not resolved), got {:?}",
-            all_test_files
+            common_mapping.is_some(),
+            "expected common/src/foo.ts to have a mapping"
+        );
+        let test_file_str = test_path.to_string_lossy().into_owned();
+        assert!(
+            common_mapping.unwrap().test_files.contains(&test_file_str),
+            "expected foo.spec.ts to be mapped to common/src/foo.ts via symlink"
+        );
+    }
+
+    // TS-B2-SYM-01: resolve_node_modules_symlink follows symlink to real path
+    #[cfg(unix)]
+    #[test]
+    fn b2_sym_01_symlink_followed() {
+        use std::os::unix::fs::symlink;
+        use tempfile::TempDir;
+
+        // Given:
+        //   scan_root/node_modules/@org/common -> ../../packages/common (symlink)
+        let dir = TempDir::new().unwrap();
+        let nm_org = dir.path().join("node_modules").join("@org");
+        std::fs::create_dir_all(&nm_org).unwrap();
+        let target = dir.path().join("packages").join("common");
+        std::fs::create_dir_all(&target).unwrap();
+        let symlink_path = nm_org.join("common");
+        symlink(&target, &symlink_path).unwrap();
+
+        let mut cache = HashMap::new();
+
+        // When: resolve_node_modules_symlink("@org/common", scan_root)
+        let result = resolve_node_modules_symlink("@org/common", dir.path(), &mut cache);
+
+        // Then: returns Some(canonical path of packages/common)
+        let expected = target.canonicalize().unwrap();
+        assert_eq!(
+            result,
+            Some(expected),
+            "expected symlink to be followed to real path"
+        );
+    }
+
+    // TS-B2-SYM-02: resolve_node_modules_symlink returns None for real directory (not symlink)
+    #[cfg(unix)]
+    #[test]
+    fn b2_sym_02_real_directory_returns_none() {
+        use tempfile::TempDir;
+
+        // Given:
+        //   scan_root/node_modules/@org/common is a real directory (not symlink)
+        let dir = TempDir::new().unwrap();
+        let nm_org = dir.path().join("node_modules").join("@org").join("common");
+        std::fs::create_dir_all(&nm_org).unwrap();
+
+        let mut cache = HashMap::new();
+
+        // When: resolve_node_modules_symlink("@org/common", scan_root)
+        let result = resolve_node_modules_symlink("@org/common", dir.path(), &mut cache);
+
+        // Then: returns None (real directory is not a monorepo symlink)
+        assert_eq!(
+            result, None,
+            "expected None for real directory (not symlink)"
+        );
+    }
+
+    // TS-B2-SYM-03: resolve_node_modules_symlink returns None for non-existent specifier
+    #[cfg(unix)]
+    #[test]
+    fn b2_sym_03_nonexistent_returns_none() {
+        use tempfile::TempDir;
+
+        // Given: scan_root/node_modules has no @org/nonexistent
+        let dir = TempDir::new().unwrap();
+        let nm = dir.path().join("node_modules");
+        std::fs::create_dir_all(&nm).unwrap();
+
+        let mut cache = HashMap::new();
+
+        // When: resolve_node_modules_symlink("@org/nonexistent", scan_root)
+        let result = resolve_node_modules_symlink("@org/nonexistent", dir.path(), &mut cache);
+
+        // Then: returns None
+        assert_eq!(result, None, "expected None for non-existent specifier");
+    }
+
+    // TS-B2-MAP-02: tsconfig alias takes priority over symlink fallback
+    #[cfg(unix)]
+    #[test]
+    fn b2_map_02_tsconfig_alias_priority() {
+        use std::os::unix::fs::symlink;
+        use tempfile::TempDir;
+
+        // Given:
+        //   packages/core/ (scan_root)
+        //   packages/core/src/foo.service.ts (production, tsconfig alias target)
+        //   packages/common/src/foo.ts (cross-package production)
+        //   packages/core/node_modules/@org/common -> ../../common (symlink)
+        //   packages/core/tsconfig.json: paths: { "@org/common": ["src/foo.service"] }
+        //   packages/core/test/foo.spec.ts: `import { Foo } from '@org/common'`
+        let dir = TempDir::new().unwrap();
+        let core_src = dir.path().join("packages").join("core").join("src");
+        let core_test = dir.path().join("packages").join("core").join("test");
+        let core_nm_org = dir
+            .path()
+            .join("packages")
+            .join("core")
+            .join("node_modules")
+            .join("@org");
+        let common_src = dir.path().join("packages").join("common").join("src");
+        std::fs::create_dir_all(&core_src).unwrap();
+        std::fs::create_dir_all(&core_test).unwrap();
+        std::fs::create_dir_all(&core_nm_org).unwrap();
+        std::fs::create_dir_all(&common_src).unwrap();
+
+        let local_prod_path = core_src.join("foo.service.ts");
+        std::fs::write(&local_prod_path, "export class FooService {}").unwrap();
+
+        let common_path = common_src.join("foo.ts");
+        std::fs::File::create(&common_path).unwrap();
+
+        let symlink_path = core_nm_org.join("common");
+        let target = dir.path().join("packages").join("common");
+        symlink(&target, &symlink_path).unwrap();
+
+        // tsconfig.json: alias @org/common -> src/foo.service
+        let tsconfig = serde_json::json!({
+            "compilerOptions": {
+                "paths": {
+                    "@org/common": ["src/foo.service"]
+                }
+            }
+        });
+        let core_root = dir.path().join("packages").join("core");
+        std::fs::write(core_root.join("tsconfig.json"), tsconfig.to_string()).unwrap();
+
+        let test_path = core_test.join("foo.spec.ts");
+        std::fs::write(
+            &test_path,
+            "import { Foo } from '@org/common';\ndescribe('Foo', () => {});",
+        )
+        .unwrap();
+
+        let production_files = vec![
+            local_prod_path.to_string_lossy().into_owned(),
+            common_path.to_string_lossy().into_owned(),
+        ];
+        let mut test_sources = HashMap::new();
+        test_sources.insert(
+            test_path.to_string_lossy().into_owned(),
+            std::fs::read_to_string(&test_path).unwrap(),
+        );
+
+        let extractor = TypeScriptExtractor::new();
+
+        // When: map_test_files_with_imports with tsconfig alias present
+        let mappings =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, &core_root);
+
+        // Then: foo.service.ts is mapped (tsconfig alias wins), common/src/foo.ts is NOT mapped
+        let test_file_str = test_path.to_string_lossy().into_owned();
+        let local_prod_str = local_prod_path.to_string_lossy().into_owned();
+        let common_path_str = common_path.to_string_lossy().into_owned();
+
+        let local_mapping = mappings
+            .iter()
+            .find(|m| m.production_file == local_prod_str);
+        assert!(
+            local_mapping.map_or(false, |m| m.test_files.contains(&test_file_str)),
+            "expected foo.service.ts to be mapped via tsconfig alias"
+        );
+
+        let common_mapping = mappings
+            .iter()
+            .find(|m| m.production_file == common_path_str);
+        assert!(
+            !common_mapping.map_or(false, |m| m.test_files.contains(&test_file_str)),
+            "expected common/src/foo.ts NOT to be mapped (tsconfig alias should win)"
+        );
+    }
+
+    // TS-B2-MULTI-01: same specifier in 2 test files both get mapped (behavior test)
+    #[cfg(unix)]
+    #[test]
+    fn b2_multi_01_two_test_files_both_mapped() {
+        use std::os::unix::fs::symlink;
+        use tempfile::TempDir;
+
+        // Given:
+        //   packages/common/src/foo.ts (production, cross-package)
+        //   packages/core/node_modules/@org/common -> ../../common (symlink)
+        //   packages/core/test/foo.spec.ts: `import { Foo } from '@org/common'`
+        //   packages/core/test/bar.spec.ts: `import { Foo } from '@org/common'`
+        let dir = TempDir::new().unwrap();
+        let core_test = dir.path().join("packages").join("core").join("test");
+        let core_nm_org = dir
+            .path()
+            .join("packages")
+            .join("core")
+            .join("node_modules")
+            .join("@org");
+        let common_src = dir.path().join("packages").join("common").join("src");
+        std::fs::create_dir_all(&core_test).unwrap();
+        std::fs::create_dir_all(&core_nm_org).unwrap();
+        std::fs::create_dir_all(&common_src).unwrap();
+
+        let common_path = common_src.join("foo.ts");
+        std::fs::File::create(&common_path).unwrap();
+
+        let symlink_path = core_nm_org.join("common");
+        let target = dir.path().join("packages").join("common");
+        symlink(&target, &symlink_path).unwrap();
+
+        let test_path1 = core_test.join("foo.spec.ts");
+        let test_path2 = core_test.join("bar.spec.ts");
+        std::fs::write(
+            &test_path1,
+            "import { Foo } from '@org/common';\ndescribe('Foo', () => {});",
+        )
+        .unwrap();
+        std::fs::write(
+            &test_path2,
+            "import { Foo } from '@org/common';\ndescribe('Bar', () => {});",
+        )
+        .unwrap();
+
+        let scan_root = dir.path().join("packages").join("core");
+        let production_files = vec![common_path.to_string_lossy().into_owned()];
+        let mut test_sources = HashMap::new();
+        test_sources.insert(
+            test_path1.to_string_lossy().into_owned(),
+            std::fs::read_to_string(&test_path1).unwrap(),
+        );
+        test_sources.insert(
+            test_path2.to_string_lossy().into_owned(),
+            std::fs::read_to_string(&test_path2).unwrap(),
+        );
+
+        let extractor = TypeScriptExtractor::new();
+
+        // When: map_test_files_with_imports
+        let mappings =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, &scan_root);
+
+        // Then: common/src/foo.ts is mapped to BOTH test files
+        let common_path_str = common_path.to_string_lossy().into_owned();
+        let test1_str = test_path1.to_string_lossy().into_owned();
+        let test2_str = test_path2.to_string_lossy().into_owned();
+
+        let common_mapping = mappings
+            .iter()
+            .find(|m| m.production_file == common_path_str);
+        assert!(
+            common_mapping.is_some(),
+            "expected common/src/foo.ts to have a mapping"
+        );
+        let mapped_tests = &common_mapping.unwrap().test_files;
+        assert!(
+            mapped_tests.contains(&test1_str),
+            "expected foo.spec.ts to be mapped"
+        );
+        assert!(
+            mapped_tests.contains(&test2_str),
+            "expected bar.spec.ts to be mapped"
         );
     }
 

--- a/docs/cycles/20260318_0955_ts-observe-b2-symlink-resolution.md
+++ b/docs/cycles/20260318_0955_ts-observe-b2-symlink-resolution.md
@@ -1,0 +1,157 @@
+---
+feature: "B2 — TypeScript observe: monorepo symlink resolution"
+cycle: "20260318_0955"
+phase: RED
+complexity: standard
+test_count: 6
+risk_level: medium
+codex_session_id: ""
+created: 2026-03-18 09:55
+updated: 2026-03-18 09:55
+---
+
+# Cycle: B2 — TypeScript observe: monorepo symlink resolution
+
+## Scope Definition
+
+### In Scope
+- [ ] `crates/lang-typescript/src/observe.rs` — `resolve_node_modules_symlink` 新関数追加
+- [ ] `crates/lang-typescript/src/observe.rs` — `resolve_base_to_file_unchecked` ヘルパー追加
+- [ ] `crates/lang-typescript/src/observe.rs` — Layer 2c ブロック (`map_test_files_with_imports` L955 挿入点)
+- [ ] `crates/lang-typescript/src/observe.rs` — boundary_b2 テスト反転
+- [ ] `docs/observe-boundaries.md` — B2 ステータス更新
+
+### Out of Scope
+- 他言語 observe への影響
+- npm (非 symlink) の実ディレクトリ解決
+- package.json main/exports パース
+- Windows 環境対応 (Unix only)
+- B6 境界の変更
+
+### Files to Change (target: 10 or less)
+- `crates/lang-typescript/src/observe.rs` (edit)
+- `docs/observe-boundaries.md` (edit)
+
+## Environment
+
+### Scope
+- Layer: Backend (`crates/lang-typescript` のみ)
+- Plugin: dev-crew:rust-quality (cargo test / clippy / fmt)
+- Risk: 35/100 (WARN) — ファイルシステム探索あり、テストで symlink 作成が必要
+
+### Runtime
+- Language: Rust (cargo test)
+
+### Dependencies (key packages)
+- tree-sitter: 既存
+- tree-sitter-typescript: 既存
+- std::fs: symlink_metadata / canonicalize
+
+### Risk Interview (BLOCK only)
+
+(BLOCK なし — リスク 35/100 WARN)
+
+## Context & Dependencies
+
+### Reference Documents
+- `crates/lang-typescript/src/observe.rs` L674 — `extract_imports_impl` (相対パスフィルタ)
+- `crates/lang-typescript/src/observe.rs` L941-955 — `map_test_files_with_imports` Layer 2c 挿入点
+- `crates/lang-typescript/src/observe.rs` L3046-3116 — boundary_b2 テスト (反転対象)
+- `crates/core/src/observe.rs` L165-208 — `resolve_absolute_base_to_file` (参考、変更なし)
+- `crates/core/src/observe.rs` L188 — `canonical.starts_with(canonical_root)` チェック (緩和対象)
+- `docs/observe-boundaries.md` — B2 境界定義
+
+### Dependent Features
+- TypeScript observe import tracing: `map_test_files_with_imports`
+- tsconfig path resolution: Layer 2b (tsconfig alias が優先)
+- barrel import resolution: 既存コードを再利用
+
+### Related Issues/PRs
+- (none)
+
+## Test List
+
+### TODO
+- [ ] TS-B2-SYM-01: symlink を follow して実体パスを返す
+- [ ] TS-B2-SYM-02: 非 symlink (実ディレクトリ) は None を返す
+- [ ] TS-B2-SYM-03: 存在しない specifier は None を返す
+- [ ] TS-B2-MAP-01: symlink 経由の cross-package mapping が TP になる
+- [ ] TS-B2-MAP-02: tsconfig alias が優先される (symlink fallback しない)
+- [ ] TS-B2-CACHE-01: 同じ specifier の2回目はキャッシュヒット
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+(none)
+
+## Implementation Notes
+
+### Goal
+TypeScript observe の NestJS eval における 7/11 FN の主因 B2 (cross-package barrel import) を解決する。yarn/pnpm workspace の node_modules symlink を follow して production file にマッピングする Layer 2c を実装する。
+
+### Background
+`import { Foo } from '@nestjs/common'` のような非相対パスは `extract_imports_impl` (L674) でフィルタされ、tsconfig alias にもマッチしない場合は解決不能になる。yarn/pnpm workspace では `node_modules/@org/common` → `../../packages/common` の symlink が作られる。この symlink を follow することで cross-package の production file にマッピングできる。
+
+### Design Approach
+
+既存パイプラインの構造:
+
+```
+Layer 2a: extract_imports_impl (相対パスのみ) → resolve_import_path → barrel/canonical lookup
+Layer 2b: extract_all_import_specifiers (非相対パスのみ) → tsconfig resolve_alias → resolve_absolute_base_to_file → barrel/canonical lookup
+Layer 2c: [NEW] tsconfig で未解決の非相対パス → node_modules symlink follow → barrel/canonical lookup
+```
+
+**新関数: `resolve_node_modules_symlink`**
+
+```rust
+fn resolve_node_modules_symlink(
+    specifier: &str,       // "@org/common"
+    scan_root: &Path,      // packages/core
+    cache: &mut HashMap<String, Option<PathBuf>>,
+) -> Option<PathBuf>
+```
+
+1. キャッシュチェック (同じ specifier の2回目以降はスキップ)
+2. `scan_root/node_modules/{specifier}` のパスを構築
+3. `std::fs::symlink_metadata()` で symlink かチェック
+4. symlink なら `std::fs::canonicalize()` で実体パスを取得
+5. 非 symlink なら None (npm install の実ディレクトリは対象外)
+
+**新ヘルパー: `resolve_base_to_file_unchecked`**
+
+core の `resolve_absolute_base_to_file` (L188) は `canonical.starts_with(canonical_root)` でフィルタする。symlink 先は scan_root 外になるため、canonical_root チェックなしのローカルヘルパーを追加。`canonical_to_idx` membership で production file かどうかを検証する。
+
+**Layer 2c 統合 (`map_test_files_with_imports` L955 以降)**
+
+```rust
+// Layer 2c: node_modules symlink resolution (monorepo)
+for (specifier, symbols) in &alias_imports {
+    // tsconfig alias で解決済みなら skip
+    if tsconfig_paths.as_ref().and_then(|tc| tc.resolve_alias(specifier)).is_some() {
+        continue;
+    }
+    // node_modules symlink follow
+    if let Some(resolved_dir) = resolve_node_modules_symlink(specifier, scan_root, &mut nm_cache) {
+        if let Some(resolved) = resolve_base_to_file_unchecked(self, &resolved_dir) {
+            collect_matches(&resolved, symbols, &mut matched_indices);
+        }
+    }
+}
+```
+
+**設計判断**:
+- scope 制約: `production_files` に cross-package のファイルが含まれていない場合は解決不可 (B6 と同じ "by design")
+- npm (非 symlink) は対象外: symlink_metadata で判別
+- package.json main/exports パースは MVP ではスキップ (`src/index.ts` barrel へのフォールバック)
+- Unix only: `std::os::unix::fs::symlink` を使うテストは `#[cfg(unix)]` ガード
+
+## Progress Log
+
+### 2026-03-18 09:55 - INIT
+- Cycle doc created
+- Scope definition ready

--- a/docs/observe-boundaries.md
+++ b/docs/observe-boundaries.md
@@ -7,7 +7,7 @@ This document catalogs the known failure boundaries of `exspec observe` -- cases
 | # | Boundary | Root Cause | Impact | Fixability |
 |---|----------|-----------|--------|------------|
 | B1 | Namespace re-export | `re_export.scm` lacks `namespace_export` pattern | FN | Medium (query addition) |
-| B2 | Cross-package barrel import | Non-relative paths excluded from import tracing | FN | Hard (requires tsconfig/node_modules resolution) |
+| B2 | Cross-package barrel import | ~~Non-relative paths excluded from import tracing~~ **Resolved in B2** (yarn/pnpm symlink follow) | ~~FN~~ Resolved | node_modules symlink resolution (Layer 2c) |
 | B3 | tsconfig path alias | ~~Same as B2~~ **Resolved in 8c-3** | ~~FN~~ Resolved | tsconfig.json paths parsing |
 | B4 | Interface/enum filter side-effect | ~~`is_non_sut_helper` filters primary test targets~~ **Resolved in 8c-4** (direct import only) | ~~FN~~ Partially resolved | Context-aware filtering with `is_known_production` |
 | B5 | Dynamic import | `import_mapping.scm` only captures static `import` statements | FN | Low (rare in test code) |
@@ -29,17 +29,22 @@ Namespace re-export (`export * as Ns from`) produces a `namespace_export` AST no
 
 **Fix path**: Add a third pattern to `re_export.scm` targeting `namespace_export` nodes. **Decision**: Treat as opaque wildcard (`wildcard: true`). Ns.Foo -> Foo resolution is out of scope — wildcard covers all public symbols in the target module, avoiding FN with minimal FP risk (barrel precision 99.4%).
 
-## B2: Cross-package barrel import (non-relative path)
+## B2: Cross-package barrel import (non-relative path) -- Resolved in B2
 
 **Syntax**: `import { Foo } from '@org/common'`
 
-**Why it fails**: `extract_imports` filters out any module specifier that does not start with `./` or `../`. Package-scoped imports (`@org/common`, `@nestjs/common`) are indistinguishable from third-party dependencies without `node_modules` resolution.
+**Root cause**: `extract_imports` filters out any module specifier that does not start with `./` or `../`. Package-scoped imports (`@org/common`, `@nestjs/common`) are indistinguishable from third-party dependencies without `node_modules` resolution.
 
-**Impact**: This is the primary FN source (7/11 FN in NestJS eval). Monorepo packages that import from sibling packages via package names lose all import-tracing signal.
+**Resolution (Phase B2)**: Layer 2c follows yarn/pnpm workspace symlinks in `node_modules`. When `scan_root/node_modules/@org/common` is a symlink (as created by yarn/pnpm workspaces), it is canonicalized to the real package directory. All production files under that directory that appear in `production_files` are then mapped to the test file. tsconfig aliases (Layer 2b) take priority -- if a specifier is already resolved by tsconfig, Layer 2c is skipped.
 
-**Tests**: `boundary_b2_non_relative_import_skipped`, `boundary_b2_cross_pkg_barrel_unresolvable`
+**Scope constraint**: `production_files` must include the cross-package file for this to work. If only scan_root files are passed, B6 applies.
 
-**Fix path**: Parse `tsconfig.json` paths or resolve `node_modules` symlinks (common in Yarn/pnpm workspaces). High complexity, high reward.
+**Remaining limitations**:
+- npm (real directories in node_modules, not symlinks) is not resolved -- only symlinks
+- package.json `main`/`exports` parsing is not supported (barrel fallback only)
+- Windows not supported (symlink creation requires Unix APIs)
+
+**Tests**: `boundary_b2_non_relative_import_skipped` (unchanged -- extract_imports still filters non-relative), `boundary_b2_cross_pkg_symlink_resolved` (TP), `b2_sym_01_symlink_followed`, `b2_sym_02_real_directory_returns_none`, `b2_sym_03_nonexistent_returns_none`, `b2_map_02_tsconfig_alias_priority`, `b2_multi_01_two_test_files_both_mapped`
 
 ## B3: tsconfig path alias (`@app/*`) -- Resolved in 8c-3
 
@@ -100,10 +105,12 @@ Namespace re-export (`export * as Ns from`) produces a `namespace_export` AST no
 Based on these boundaries, observe is most reliable for:
 
 - **Single-package TypeScript projects** (no B2/B3/B6 impact)
-- **Projects using relative imports or tsconfig path aliases** (no B2 impact, B3 resolved)
+- **Projects using relative imports or tsconfig path aliases** (B2 resolved, B3 resolved)
 - **Projects with standard barrel patterns** (`export { X } from` or `export * from`, no B1 impact)
 
+- **yarn/pnpm monorepo workspaces** with cross-package imports (B2 resolved via symlink follow)
+
 Observe is **less reliable** for:
-- **Monorepo workspaces** with cross-package imports via node_modules (B2, B6)
+- **npm monorepo workspaces** with real-directory node_modules (not symlinks) for cross-package deps (B6)
 - **Projects heavy on namespace re-exports** (B1)
 - **Projects where enums/interfaces are re-exported through barrels** (B4 partial)


### PR DESCRIPTION
## Summary
- Add `resolve_node_modules_symlink` to follow yarn/pnpm workspace symlinks in `node_modules/` for cross-package import resolution
- Insert Layer 2c in `map_test_files_with_imports`: after tsconfig alias (Layer 2b) fails, fall back to symlink follow
- tsconfig alias takes priority; real directories (npm install) are skipped to avoid FP

## Test plan
- [x] TS-B2-SYM-01: symlink followed to real path
- [x] TS-B2-SYM-02: real directory returns None
- [x] TS-B2-SYM-03: nonexistent specifier returns None
- [x] TS-B2-MAP-01: cross-package mapping via symlink is TP
- [x] TS-B2-MAP-02: tsconfig alias takes priority over symlink
- [x] TS-B2-MULTI-01: two test files with same specifier both mapped
- [x] boundary_b2 test inverted (FN → TP)
- [x] All 951 tests pass, clippy clean, fmt clean, self-dogfooding BLOCK 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)