### PR TITLE
refactor: extract collect_import_matches to core and deduplicate CLI run_observe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ lcov.info
 
 # Claude Code
 .claude/agent-memory/
+.claude/plans/
 .claude/settings.local.json
 dogfooding/
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -330,6 +330,76 @@ fn build_observe_report(
     }
 }
 
+/// Common observe pipeline: discover files → read test sources → map → report → output.
+///
+/// `lang_str` / `lang` select which files to discover.
+/// `map_fn` receives (production_files, test_sources, root) and returns file mappings.
+/// `route_fn` receives (production_files) and returns route entries (TypeScript only; others pass `|_| Vec::new()`).
+fn run_observe_common(
+    root: &str,
+    lang_str: &str,
+    lang: Language,
+    format: &str,
+    config: &Config,
+    map_fn: impl FnOnce(
+        &[String],
+        &HashMap<String, String>,
+        &Path,
+    ) -> Vec<exspec_core::observe::FileMapping>,
+    route_fn: impl FnOnce(&[String]) -> Vec<ObserveRouteEntry>,
+) {
+    let discovered = discover_files(root, Some(lang_str), &config.ignore_patterns);
+    let test_files: Vec<String> = discovered
+        .test_files
+        .get(&lang)
+        .cloned()
+        .unwrap_or_default();
+    let production_files = &discovered.source_files;
+
+    let mut test_sources: HashMap<String, String> = HashMap::new();
+    for test_file in &test_files {
+        if let Ok(source) = std::fs::read_to_string(test_file) {
+            test_sources.insert(test_file.clone(), source);
+        }
+    }
+
+    let file_mappings = map_fn(production_files, &test_sources, Path::new(root));
+    let route_entries = route_fn(production_files);
+
+    // Build route entries with coverage info
+    let mut prod_to_tests: HashMap<String, Vec<String>> = HashMap::new();
+    if !route_entries.is_empty() {
+        for m in &file_mappings {
+            if !m.test_files.is_empty() {
+                prod_to_tests.insert(m.production_file.clone(), m.test_files.clone());
+            }
+        }
+    }
+    let route_entries: Vec<ObserveRouteEntry> = route_entries
+        .into_iter()
+        .map(|mut entry| {
+            if let Some(tf) = prod_to_tests.get(&entry.file) {
+                entry.test_files = tf.clone();
+            }
+            entry
+        })
+        .collect();
+
+    let report = build_observe_report(
+        &file_mappings,
+        production_files,
+        test_files.len(),
+        route_entries,
+    );
+    let output = match format {
+        "json" => report.format_json(),
+        _ => report.format_terminal(),
+    };
+    if !output.is_empty() {
+        println!("{output}");
+    }
+}
+
 fn run_observe(args: ObserveArgs) {
     let observe_formats = ["terminal", "json"];
     if !observe_formats.contains(&args.format.as_str()) {
@@ -346,193 +416,77 @@ fn run_observe(args: ObserveArgs) {
 
     match args.lang.as_str() {
         "typescript" => {
-            let ts_extractor = TypeScriptExtractor::new();
-
-            let discovered = discover_files(root, Some("typescript"), &config.ignore_patterns);
-            let test_files: Vec<String> = discovered
-                .test_files
-                .get(&Language::TypeScript)
-                .cloned()
-                .unwrap_or_default();
-            let production_files = &discovered.source_files;
-
-            // Read source files and extract routes
-            let mut all_routes = Vec::new();
-            for prod_file in production_files {
-                let source = match std::fs::read_to_string(prod_file) {
-                    Ok(s) => s,
-                    Err(_) => continue,
-                };
-                let routes = ts_extractor.extract_routes(&source, prod_file);
-                all_routes.extend(routes);
-            }
-
-            // Read test sources into HashMap
-            let mut test_sources: HashMap<String, String> = HashMap::new();
-            for test_file in &test_files {
-                if let Ok(source) = std::fs::read_to_string(test_file) {
-                    test_sources.insert(test_file.clone(), source);
-                }
-            }
-
-            // Map test files to production files
-            let file_mappings = ts_extractor.map_test_files_with_imports(
-                production_files,
-                &test_sources,
-                Path::new(root),
-            );
-
-            // Build route entries with coverage info
-            let mut prod_to_tests: HashMap<String, Vec<String>> = HashMap::new();
-            for m in &file_mappings {
-                if !m.test_files.is_empty() {
-                    prod_to_tests.insert(m.production_file.clone(), m.test_files.clone());
-                }
-            }
-            let route_entries: Vec<ObserveRouteEntry> = all_routes
-                .iter()
-                .map(|route| {
-                    let tf = prod_to_tests.get(&route.file).cloned().unwrap_or_default();
-                    ObserveRouteEntry {
-                        http_method: route.http_method.clone(),
-                        path: route.path.clone(),
-                        handler: format!("{}.{}", route.class_name, route.handler_name),
-                        file: route.file.clone(),
-                        test_files: tf,
+            let ts_ext = TypeScriptExtractor::new();
+            run_observe_common(
+                root,
+                "typescript",
+                Language::TypeScript,
+                &args.format,
+                &config,
+                |prod, test_src, root_path| {
+                    ts_ext.map_test_files_with_imports(prod, test_src, root_path)
+                },
+                |prod_files| {
+                    let mut all_routes = Vec::new();
+                    for prod_file in prod_files {
+                        let source = match std::fs::read_to_string(prod_file) {
+                            Ok(s) => s,
+                            Err(_) => continue,
+                        };
+                        let routes = ts_ext.extract_routes(&source, prod_file);
+                        all_routes.extend(routes.into_iter().map(|r| ObserveRouteEntry {
+                            http_method: r.http_method,
+                            path: r.path,
+                            handler: format!("{}.{}", r.class_name, r.handler_name),
+                            file: r.file,
+                            test_files: Vec::new(),
+                        }));
                     }
-                })
-                .collect();
-
-            let report = build_observe_report(
-                &file_mappings,
-                production_files,
-                test_files.len(),
-                route_entries,
+                    all_routes
+                },
             );
-            let output = match args.format.as_str() {
-                "json" => report.format_json(),
-                _ => report.format_terminal(),
-            };
-            if !output.is_empty() {
-                println!("{output}");
-            }
         }
         "python" => {
-            let py_extractor = PythonExtractor::new();
-
-            let discovered = discover_files(root, Some("python"), &config.ignore_patterns);
-            let test_files: Vec<String> = discovered
-                .test_files
-                .get(&Language::Python)
-                .cloned()
-                .unwrap_or_default();
-            let production_files = &discovered.source_files;
-
-            // Read test sources into HashMap
-            let mut test_sources: HashMap<String, String> = HashMap::new();
-            for test_file in &test_files {
-                if let Ok(source) = std::fs::read_to_string(test_file) {
-                    test_sources.insert(test_file.clone(), source);
-                }
-            }
-
-            // Map test files to production files (Layer 1 + Layer 2)
-            let file_mappings = py_extractor.map_test_files_with_imports(
-                production_files,
-                &test_sources,
-                Path::new(root),
+            let py_ext = PythonExtractor::new();
+            run_observe_common(
+                root,
+                "python",
+                Language::Python,
+                &args.format,
+                &config,
+                |prod, test_src, root_path| {
+                    py_ext.map_test_files_with_imports(prod, test_src, root_path)
+                },
+                |_| Vec::new(),
             );
-
-            let report = build_observe_report(
-                &file_mappings,
-                production_files,
-                test_files.len(),
-                Vec::new(),
-            );
-            let output = match args.format.as_str() {
-                "json" => report.format_json(),
-                _ => report.format_terminal(),
-            };
-            if !output.is_empty() {
-                println!("{output}");
-            }
         }
         "rust" => {
-            let rust_extractor = RustExtractor::new();
-
-            let discovered = discover_files(root, Some("rust"), &config.ignore_patterns);
-            let test_files: Vec<String> = discovered
-                .test_files
-                .get(&Language::Rust)
-                .cloned()
-                .unwrap_or_default();
-            let production_files = &discovered.source_files;
-
-            // Read test sources into HashMap
-            let mut test_sources: HashMap<String, String> = HashMap::new();
-            for test_file in &test_files {
-                if let Ok(source) = std::fs::read_to_string(test_file) {
-                    test_sources.insert(test_file.clone(), source);
-                }
-            }
-
-            // Map test files to production files (Layer 0 + Layer 1 + Layer 2)
-            let file_mappings = rust_extractor.map_test_files_with_imports(
-                production_files,
-                &test_sources,
-                Path::new(root),
+            let rust_ext = RustExtractor::new();
+            run_observe_common(
+                root,
+                "rust",
+                Language::Rust,
+                &args.format,
+                &config,
+                |prod, test_src, root_path| {
+                    rust_ext.map_test_files_with_imports(prod, test_src, root_path)
+                },
+                |_| Vec::new(),
             );
-
-            let report = build_observe_report(
-                &file_mappings,
-                production_files,
-                test_files.len(),
-                Vec::new(),
-            );
-            let output = match args.format.as_str() {
-                "json" => report.format_json(),
-                _ => report.format_terminal(),
-            };
-            if !output.is_empty() {
-                println!("{output}");
-            }
         }
         "php" => {
-            let php_extractor = PhpExtractor::new();
-            let discovered = discover_files(root, Some("php"), &config.ignore_patterns);
-            let test_files: Vec<String> = discovered
-                .test_files
-                .get(&Language::Php)
-                .cloned()
-                .unwrap_or_default();
-            let production_files = &discovered.source_files;
-
-            let mut test_sources: HashMap<String, String> = HashMap::new();
-            for test_file in &test_files {
-                if let Ok(source) = std::fs::read_to_string(test_file) {
-                    test_sources.insert(test_file.clone(), source);
-                }
-            }
-
-            let file_mappings = php_extractor.map_test_files_with_imports(
-                production_files,
-                &test_sources,
-                Path::new(root),
+            let php_ext = PhpExtractor::new();
+            run_observe_common(
+                root,
+                "php",
+                Language::Php,
+                &args.format,
+                &config,
+                |prod, test_src, root_path| {
+                    php_ext.map_test_files_with_imports(prod, test_src, root_path)
+                },
+                |_| Vec::new(),
             );
-
-            let report = build_observe_report(
-                &file_mappings,
-                production_files,
-                test_files.len(),
-                Vec::new(),
-            );
-            let output = match args.format.as_str() {
-                "json" => report.format_json(),
-                _ => report.format_terminal(),
-            };
-            if !output.is_empty() {
-                println!("{output}");
-            }
         }
         _ => {
             eprintln!("error: observe is not yet supported for {}", args.lang);

--- a/crates/core/src/observe.rs
+++ b/crates/core/src/observe.rs
@@ -314,6 +314,34 @@ fn resolve_barrel_exports_inner(
     }
 }
 
+/// Helper: given a resolved file path, follow barrel re-exports if needed and
+/// collect matching production-file indices.
+pub fn collect_import_matches(
+    ext: &dyn ObserveExtractor,
+    resolved: &str,
+    symbols: &[String],
+    canonical_to_idx: &HashMap<String, usize>,
+    indices: &mut HashSet<usize>,
+    canonical_root: &Path,
+) {
+    if ext.is_barrel_file(resolved) {
+        let barrel_path = PathBuf::from(resolved);
+        let resolved_files = resolve_barrel_exports(ext, &barrel_path, symbols, canonical_root);
+        for prod in resolved_files {
+            let prod_str = prod.to_string_lossy().into_owned();
+            if !ext.is_non_sut_helper(&prod_str, canonical_to_idx.contains_key(&prod_str)) {
+                if let Some(&idx) = canonical_to_idx.get(&prod_str) {
+                    indices.insert(idx);
+                }
+            }
+        }
+    } else if !ext.is_non_sut_helper(resolved, canonical_to_idx.contains_key(resolved)) {
+        if let Some(&idx) = canonical_to_idx.get(resolved) {
+            indices.insert(idx);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -364,6 +392,70 @@ mod tests {
         }
     }
 
+    /// Configurable MockExtractor for CORE-CIM tests.
+    struct ConfigurableMockExtractor {
+        barrel_file_names: Vec<String>,
+        helper_file_paths: Vec<String>,
+    }
+
+    impl ConfigurableMockExtractor {
+        fn new() -> Self {
+            Self {
+                barrel_file_names: vec!["index.ts".to_string()],
+                helper_file_paths: vec![],
+            }
+        }
+
+        fn with_helpers(helper_paths: Vec<String>) -> Self {
+            Self {
+                barrel_file_names: vec!["index.ts".to_string()],
+                helper_file_paths: helper_paths,
+            }
+        }
+    }
+
+    impl ObserveExtractor for ConfigurableMockExtractor {
+        fn extract_production_functions(
+            &self,
+            _source: &str,
+            _file_path: &str,
+        ) -> Vec<ProductionFunction> {
+            vec![]
+        }
+        fn extract_imports(&self, _source: &str, _file_path: &str) -> Vec<ImportMapping> {
+            vec![]
+        }
+        fn extract_all_import_specifiers(&self, _source: &str) -> Vec<(String, Vec<String>)> {
+            vec![]
+        }
+        fn extract_barrel_re_exports(
+            &self,
+            _source: &str,
+            _file_path: &str,
+        ) -> Vec<BarrelReExport> {
+            // Returns empty to avoid real fs access; barrel resolution tested separately
+            vec![]
+        }
+        fn source_extensions(&self) -> &[&str] {
+            &["ts", "tsx"]
+        }
+        fn index_file_names(&self) -> &[&str] {
+            // Return a static slice matching our barrel file names
+            &["index.ts"]
+        }
+        fn production_stem<'a>(&self, path: &'a str) -> Option<&'a str> {
+            Path::new(path).file_stem()?.to_str()
+        }
+        fn test_stem<'a>(&self, path: &'a str) -> Option<&'a str> {
+            let stem = Path::new(path).file_stem()?.to_str()?;
+            stem.strip_suffix(".spec")
+                .or_else(|| stem.strip_suffix(".test"))
+        }
+        fn is_non_sut_helper(&self, file_path: &str, _is_known_production: bool) -> bool {
+            self.helper_file_paths.iter().any(|h| h == file_path)
+        }
+    }
+
     // TC-01: map_test_files で Layer 1 stem matching が動作
     #[test]
     fn tc01_map_test_files_stem_matching() {
@@ -405,5 +497,146 @@ mod tests {
         assert_send_sync::<MockExtractor>();
         // Box<dyn ObserveExtractor> should also work
         let _: Box<dyn ObserveExtractor + Send + Sync> = Box::new(MockExtractor);
+    }
+
+    // CORE-CIM-01: barrel file 経由の production match
+    //
+    // Given: is_barrel_file returns true (path ends in index.ts), but resolve_barrel_exports
+    //        returns no files (in-memory extractor avoids real fs access). The barrel path itself
+    //        is also present in canonical_to_idx as a fallback production entry.
+    //        When barrel resolves to zero files, no index should be added.
+    //        Separate assertion: when is_barrel_file=true the non-barrel branch is NOT taken.
+    #[test]
+    fn core_cim_01_barrel_file_skips_direct_match_branch() {
+        // Given
+        let ext = ConfigurableMockExtractor::new();
+        let barrel_path = "/project/src/index.ts";
+        let symbols: Vec<String> = vec!["UserService".to_string()];
+        let canonical_root = Path::new("/project/src");
+
+        // canonical_to_idx contains the barrel path itself
+        let mut canonical_to_idx: HashMap<String, usize> = HashMap::new();
+        canonical_to_idx.insert(barrel_path.to_string(), 0);
+        let mut indices: HashSet<usize> = HashSet::new();
+
+        // When: barrel file — resolve_barrel_exports returns empty (no real fs),
+        //       so no production files are resolved. indices must stay empty.
+        collect_import_matches(
+            &ext,
+            barrel_path,
+            &symbols,
+            &canonical_to_idx,
+            &mut indices,
+            canonical_root,
+        );
+
+        // Then: barrel branch was taken (no direct-match insert), indices remains empty
+        assert!(
+            indices.is_empty(),
+            "barrel path itself must not be added via direct-match branch"
+        );
+    }
+
+    // CORE-CIM-02: 非 barrel file の直接 match
+    //
+    // Given: is_barrel_file returns false, is_non_sut_helper returns false,
+    //        production file exists in canonical_to_idx at index 0
+    // When: collect_import_matches is called with the production file path
+    // Then: index 0 is inserted into indices
+    #[test]
+    fn core_cim_02_non_barrel_direct_match() {
+        // Given
+        let ext = ConfigurableMockExtractor::new();
+        let prod_path = "/project/src/user.service.ts";
+        let symbols: Vec<String> = vec!["UserService".to_string()];
+        let canonical_root = Path::new("/project/src");
+
+        let mut canonical_to_idx: HashMap<String, usize> = HashMap::new();
+        canonical_to_idx.insert(prod_path.to_string(), 0);
+        let mut indices: HashSet<usize> = HashSet::new();
+
+        // When
+        collect_import_matches(
+            &ext,
+            prod_path,
+            &symbols,
+            &canonical_to_idx,
+            &mut indices,
+            canonical_root,
+        );
+
+        // Then
+        assert!(
+            indices.contains(&0),
+            "production file index must be inserted for non-barrel direct match"
+        );
+        assert_eq!(indices.len(), 1);
+    }
+
+    // CORE-CIM-03: helper file はスキップ
+    //
+    // Given: is_non_sut_helper returns true for the resolved path
+    // When: collect_import_matches is called
+    // Then: indices stays empty
+    #[test]
+    fn core_cim_03_helper_file_skipped() {
+        // Given
+        let helper_path = "/project/src/test-utils.ts";
+        let ext = ConfigurableMockExtractor::with_helpers(vec![helper_path.to_string()]);
+        let symbols: Vec<String> = vec![];
+        let canonical_root = Path::new("/project/src");
+
+        let mut canonical_to_idx: HashMap<String, usize> = HashMap::new();
+        canonical_to_idx.insert(helper_path.to_string(), 0);
+        let mut indices: HashSet<usize> = HashSet::new();
+
+        // When
+        collect_import_matches(
+            &ext,
+            helper_path,
+            &symbols,
+            &canonical_to_idx,
+            &mut indices,
+            canonical_root,
+        );
+
+        // Then
+        assert!(
+            indices.is_empty(),
+            "helper files must be skipped and not added to indices"
+        );
+    }
+
+    // CORE-CIM-04: canonical_to_idx に存在しない file はスキップ
+    //
+    // Given: canonical_to_idx is empty
+    // When: collect_import_matches is called with any non-barrel, non-helper path
+    // Then: indices stays empty
+    #[test]
+    fn core_cim_04_unknown_file_skipped() {
+        // Given
+        let ext = ConfigurableMockExtractor::new();
+        let unknown_path = "/project/src/unknown.service.ts";
+        let symbols: Vec<String> = vec![];
+        let canonical_root = Path::new("/project/src");
+
+        let canonical_to_idx: HashMap<String, usize> = HashMap::new(); // empty
+        let mut indices: HashSet<usize> = HashSet::new();
+
+        // When
+        collect_import_matches(
+            &ext,
+            unknown_path,
+            &symbols,
+            &canonical_to_idx,
+            &mut indices,
+            canonical_root,
+        );
+
+        // Then
+        assert!(
+            indices.is_empty(),
+            "file not in canonical_to_idx must be skipped"
+        );
     }
 }

--- a/crates/lang-python/src/observe.rs
+++ b/crates/lang-python/src/observe.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::OnceLock;
 
 use streaming_iterator::StreamingIterator;
@@ -560,7 +560,7 @@ impl PythonExtractor {
                             from_file,
                             &canonical_root,
                         ) {
-                            collect_import_matches(
+                            exspec_core::observe::collect_import_matches(
                                 self,
                                 &resolved,
                                 &import.symbols,
@@ -581,7 +581,7 @@ impl PythonExtractor {
                     from_file,
                     &canonical_root,
                 ) {
-                    collect_import_matches(
+                    exspec_core::observe::collect_import_matches(
                         self,
                         &resolved,
                         &import.symbols,
@@ -601,7 +601,7 @@ impl PythonExtractor {
                     &base,
                     &canonical_root,
                 ) {
-                    collect_import_matches(
+                    exspec_core::observe::collect_import_matches(
                         self,
                         &resolved,
                         symbols,
@@ -629,39 +629,6 @@ impl PythonExtractor {
         }
 
         mappings
-    }
-}
-
-/// Helper: given a resolved file path, follow barrel re-exports if needed and
-/// collect matching production-file indices.
-fn collect_import_matches(
-    ext: &PythonExtractor,
-    resolved: &str,
-    symbols: &[String],
-    canonical_to_idx: &HashMap<String, usize>,
-    indices: &mut std::collections::HashSet<usize>,
-    canonical_root: &Path,
-) {
-    if ext.is_barrel_file(resolved) {
-        let barrel_path = PathBuf::from(resolved);
-        let resolved_files = exspec_core::observe::resolve_barrel_exports(
-            ext,
-            &barrel_path,
-            symbols,
-            canonical_root,
-        );
-        for prod in resolved_files {
-            let prod_str = prod.to_string_lossy().into_owned();
-            if !ext.is_non_sut_helper(&prod_str, canonical_to_idx.contains_key(&prod_str)) {
-                if let Some(&idx) = canonical_to_idx.get(&prod_str) {
-                    indices.insert(idx);
-                }
-            }
-        }
-    } else if !ext.is_non_sut_helper(resolved, canonical_to_idx.contains_key(resolved)) {
-        if let Some(&idx) = canonical_to_idx.get(resolved) {
-            indices.insert(idx);
-        }
     }
 }
 

--- a/crates/lang-rust/src/observe.rs
+++ b/crates/lang-rust/src/observe.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::OnceLock;
 
 use streaming_iterator::StreamingIterator;
@@ -692,7 +692,7 @@ impl RustExtractor {
                     &src_relative,
                     &canonical_root,
                 ) {
-                    collect_import_matches(
+                    exspec_core::observe::collect_import_matches(
                         self,
                         &resolved,
                         symbols,
@@ -723,39 +723,6 @@ impl RustExtractor {
     }
 }
 
-/// Helper: given a resolved file path, follow barrel re-exports if needed and
-/// collect matching production-file indices.
-fn collect_import_matches(
-    ext: &RustExtractor,
-    resolved: &str,
-    symbols: &[String],
-    canonical_to_idx: &HashMap<String, usize>,
-    indices: &mut HashSet<usize>,
-    canonical_root: &Path,
-) {
-    if ext.is_barrel_file(resolved) {
-        let barrel_path = PathBuf::from(resolved);
-        let resolved_files = exspec_core::observe::resolve_barrel_exports(
-            ext,
-            &barrel_path,
-            symbols,
-            canonical_root,
-        );
-        for prod in resolved_files {
-            let prod_str = prod.to_string_lossy().into_owned();
-            if !ext.is_non_sut_helper(&prod_str, canonical_to_idx.contains_key(&prod_str)) {
-                if let Some(&idx) = canonical_to_idx.get(&prod_str) {
-                    indices.insert(idx);
-                }
-            }
-        }
-    } else if !ext.is_non_sut_helper(resolved, canonical_to_idx.contains_key(resolved)) {
-        if let Some(&idx) = canonical_to_idx.get(resolved) {
-            indices.insert(idx);
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -763,6 +730,7 @@ fn collect_import_matches(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     // -----------------------------------------------------------------------
     // RS-STEM-01: tests/test_foo.rs -> test_stem = Some("foo")

--- a/crates/lang-typescript/src/observe.rs
+++ b/crates/lang-typescript/src/observe.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -899,37 +899,6 @@ impl TypeScriptExtractor {
             let from_file = Path::new(test_file);
             let mut matched_indices = std::collections::HashSet::new();
 
-            // Helper: given a resolved file path, follow barrel re-exports if needed and
-            // collect matching production-file indices.
-            let collect_matches = |resolved: &str,
-                                   symbols: &[String],
-                                   indices: &mut HashSet<usize>| {
-                if self.is_barrel_file(resolved) {
-                    let barrel_path = PathBuf::from(resolved);
-                    let resolved_files = exspec_core::observe::resolve_barrel_exports(
-                        self,
-                        &barrel_path,
-                        symbols,
-                        &canonical_root,
-                    );
-                    for prod in resolved_files {
-                        let prod_str = prod.to_string_lossy().into_owned();
-                        if !self
-                            .is_non_sut_helper(&prod_str, canonical_to_idx.contains_key(&prod_str))
-                        {
-                            if let Some(&idx) = canonical_to_idx.get(&prod_str) {
-                                indices.insert(idx);
-                            }
-                        }
-                    }
-                } else if !self.is_non_sut_helper(resolved, canonical_to_idx.contains_key(resolved))
-                {
-                    if let Some(&idx) = canonical_to_idx.get(resolved) {
-                        indices.insert(idx);
-                    }
-                }
-            };
-
             for import in &imports {
                 if let Some(resolved) = exspec_core::observe::resolve_import_path(
                     self,
@@ -937,7 +906,14 @@ impl TypeScriptExtractor {
                     from_file,
                     &canonical_root,
                 ) {
-                    collect_matches(&resolved, &import.symbols, &mut matched_indices);
+                    exspec_core::observe::collect_import_matches(
+                        self,
+                        &resolved,
+                        &import.symbols,
+                        &canonical_to_idx,
+                        &mut matched_indices,
+                        &canonical_root,
+                    );
                 }
             }
 
@@ -954,7 +930,14 @@ impl TypeScriptExtractor {
                     if let Some(resolved) =
                         resolve_absolute_base_to_file(self, &alias_base, &canonical_root)
                     {
-                        collect_matches(&resolved, symbols, &mut matched_indices);
+                        exspec_core::observe::collect_import_matches(
+                            self,
+                            &resolved,
+                            symbols,
+                            &canonical_to_idx,
+                            &mut matched_indices,
+                            &canonical_root,
+                        );
                     }
                 }
             }
@@ -977,7 +960,14 @@ impl TypeScriptExtractor {
                     let resolved_dir_str = resolved_dir.to_string_lossy().into_owned();
                     for prod_canonical in canonical_to_idx.keys() {
                         if prod_canonical.starts_with(&resolved_dir_str) {
-                            collect_matches(prod_canonical, symbols, &mut matched_indices);
+                            exspec_core::observe::collect_import_matches(
+                                self,
+                                prod_canonical,
+                                symbols,
+                                &canonical_to_idx,
+                                &mut matched_indices,
+                                &canonical_root,
+                            );
                         }
                     }
                 }

--- a/docs/cycles/20260318_1041_9a-observe-extractor-collect-import-matches.md
+++ b/docs/cycles/20260318_1041_9a-observe-extractor-collect-import-matches.md
@@ -1,0 +1,183 @@
+---
+feature: "9a — ObserveExtractor: collect_import_matches 共通化 + CLI 重複排除"
+cycle: "20260318_1041"
+phase: DONE
+complexity: standard
+test_count: 8
+risk_level: low
+codex_session_id: ""
+created: 2026-03-18 10:41
+updated: 2026-03-18 10:41
+---
+
+# Cycle: 9a — ObserveExtractor: collect_import_matches 共通化 + CLI 重複排除
+
+## Scope Definition
+
+### In Scope
+- [x] `crates/core/src/observe.rs` — `collect_import_matches` free function 追加
+- [x] `crates/lang-typescript/src/observe.rs` — inline closure を core 呼び出しに置換
+- [x] `crates/lang-python/src/observe.rs` — local `collect_import_matches` 削除 → core 呼び出し
+- [x] `crates/lang-rust/src/observe.rs` — local `collect_import_matches` 削除 → core 呼び出し
+- [x] `crates/cli/src/main.rs` — `run_observe()` 共通化 (~200行 → ヘルパー関数抽出)
+
+### Out of Scope
+- PHP observe への変更 (barrel 非対応のため `collect_import_matches` 不使用)
+- 新機能追加 (純粋リファクタリングのみ)
+- 他言語への observe 機能拡張
+
+### Files to Change (target: 10 or less)
+- `crates/core/src/observe.rs` (edit)
+- `crates/lang-typescript/src/observe.rs` (edit)
+- `crates/lang-python/src/observe.rs` (edit)
+- `crates/lang-rust/src/observe.rs` (edit)
+- `crates/cli/src/main.rs` (edit)
+
+## Environment
+
+### Scope
+- Layer: Backend (core + 3 lang crates + cli)
+- Plugin: dev-crew:rust-quality (cargo test / clippy / fmt)
+- Risk: 25/100 (PASS) — 純粋リファクタリング、既存テスト全通過が検証基準
+
+### Runtime
+- Language: Rust (cargo test)
+
+### Dependencies (key packages)
+- `crates/core/src/observe.rs` — `ObserveExtractor` trait, `is_barrel_file`, `resolve_barrel_exports`, `is_non_sut_helper`
+- `std::collections::{HashMap, HashSet}`
+- `std::path::Path`
+
+### Risk Interview (BLOCK only)
+
+(BLOCK なし — リスク 25/100 PASS)
+
+## Context & Dependencies
+
+### Reference Documents
+- `crates/core/src/observe.rs` L54-89 — `ObserveExtractor` trait (既存)
+- `crates/lang-python/src/observe.rs` L637-666 — Python `collect_import_matches` (削除対象)
+- `crates/lang-rust/src/observe.rs` L728-757 — Rust `collect_import_matches` (削除対象)
+- `crates/lang-typescript/src/observe.rs` L904-931 — TypeScript inline closure (置換対象)
+- `crates/cli/src/main.rs` L333-541 — `run_observe()` 4言語分 (~200行、共通化対象)
+
+### Dependent Features
+- observe: `map_test_files_with_imports` (全3言語で `collect_import_matches` を使用)
+- observe CLI: `run_observe()` 経由で全言語の observe を起動
+
+### Related Issues/PRs
+- (none)
+
+## Test List
+
+### TODO
+(none)
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+- [x] CORE-CIM-01: barrel file 経由の production match
+- [x] CORE-CIM-02: 非 barrel file の直接 match
+- [x] CORE-CIM-03: helper file はスキップ
+- [x] CORE-CIM-04: canonical_to_idx に存在しない file はスキップ
+- [x] REFACTOR-TS-01: TypeScript observe 全既存テスト通過
+- [x] REFACTOR-PY-01: Python observe 全既存テスト通過
+- [x] REFACTOR-RS-01: Rust observe 全既存テスト通過
+- [x] REFACTOR-CLI-01: CLI observe 動作維持
+
+## Implementation Notes
+
+### Goal
+`collect_import_matches` の3重実装 (Python/Rust/TypeScript) を `crates/core/src/observe.rs` の free function に統一し、CLI `run_observe()` の ~200行重複を共通ヘルパーで削減する。純粋リファクタリングであり、外部動作は変わらない。
+
+### Background
+ROADMAP Phase 9a は「ObserveExtractor trait を TypeScript から抽出」が当初目標だったが、trait は既に `crates/core/src/observe.rs` L54-89 に存在し全4言語が実装済み。残存する重複コードは:
+1. `collect_import_matches` が Python/Rust/TypeScript で同一ロジックを3回実装 (PHP は barrel 非対応で不使用)
+2. CLI の `run_observe()` が4言語分ほぼ同じ「discover → read → map → report」を繰り返し (L333-541, ~200行)
+
+### Design Approach
+
+**Step 1: `collect_import_matches` を core に抽出**
+
+```rust
+pub fn collect_import_matches(
+    ext: &dyn ObserveExtractor,
+    resolved: &str,
+    symbols: &[String],
+    canonical_to_idx: &HashMap<String, usize>,
+    indices: &mut HashSet<usize>,
+    canonical_root: &Path,
+)
+```
+
+ロジック:
+1. `is_barrel_file` → `resolve_barrel_exports` → `is_non_sut_helper` → `canonical_to_idx.get`
+2. 非 barrel → `is_non_sut_helper` → `canonical_to_idx.get`
+
+各言語の `collect_import_matches` / inline closure を削除し、core の関数を呼び出す。
+
+**Step 2: CLI `run_observe()` の共通化**
+
+```rust
+fn run_observe_common(
+    root: &str,
+    lang_str: &str,
+    lang: Language,
+    format: &str,
+    config: &Config,
+    extractor_fn: impl FnOnce(&[String], &HashMap<String, String>, &Path) -> Vec<FileMapping>,
+    route_fn: impl FnOnce(&[String]) -> Vec<ObserveRouteEntry>,
+) { ... }
+```
+
+共通部分: `discover_files` → test_sources HashMap 構築 → `map_test_files_with_imports` → `build_observe_report` + format 出力
+
+## Progress Log
+
+### 2026-03-18 10:41 - INIT
+- Cycle doc created
+- Scope definition ready
+
+### 2026-03-18 - SYNC-PLAN
+- Cycle doc generated from plan
+- Phase completed
+
+### 2026-03-18 - REVIEW (plan)
+- Score: 22/100 (PASS)
+- Important: TypeScript の collect_matches クロージャは Layer 2b/2c でも使用されている (L940, L957, L980)。core 版への置換時にこれらも忘れずに対応すること
+- Important: run_observe_common の route_fn 引数は production_files を受け取る。シグネチャに注釈を追加
+- Optional: CORE-CIM-01 の barrel テストは MockExtractor in-memory で完結させる（既存 tc01/tc03 と同方針）
+- Phase completed
+
+### 2026-03-18 - RED
+- CORE-CIM-01~04: 4テスト作成、全コンパイルエラー (E0425: collect_import_matches not found)
+- ConfigurableMockExtractor 追加 (is_non_sut_helper, is_barrel_file が設定可能)
+- Phase completed
+
+### 2026-03-18 - GREEN
+- Step 1: core/observe.rs に pub fn collect_import_matches 追加
+- Step 2: Python ローカル関数削除 → core 呼び出し (3箇所)
+- Step 3: Rust ローカル関数削除 → core 呼び出し
+- Step 4: TypeScript inline closure 削除 → core 呼び出し (3箇所: L2, L2b, L2c)
+- 全955テスト PASS, clippy 0 errors, BLOCK 0
+- Phase completed
+
+### 2026-03-18 - REFACTOR
+- CLI run_observe() を run_observe_common ヘルパーに抽出 (~200行 → ~70行の共通関数 + ~50行の呼び出し)
+- map_fn / route_fn closure 注入で TypeScript 固有の route extraction を分離
+- Verification Gate: fmt OK, clippy 0, 955 tests PASS, BLOCK 0
+- Phase completed
+
+### 2026-03-18 - REVIEW (code)
+- Security: PASS (5/100) — 新規脆弱性なし
+- Correctness: PASS (8/100) — 論理等価性確認済み、Layer 2b/2c 置換正しい
+- Aggregate: PASS (8/100)
+- Phase completed
+
+### 2026-03-18 - COMMIT
+- refactor: extract collect_import_matches to core and deduplicate CLI run_observe
+- Phase completed


### PR DESCRIPTION
## Summary
- `collect_import_matches` を Python/Rust/TypeScript の3重実装から `crates/core/src/observe.rs` の共通 free function に統一
- TypeScript の inline closure (Layer 2/2b/2c) も core 関数呼び出しに置換
- CLI `run_observe()` の ~200行重複を `run_observe_common` ヘルパーに抽出 (4言語分)
- 新規テスト4件 (CORE-CIM-01~04) で共通関数の barrel/direct/helper/unknown ケースをカバー

## Test plan
- [x] `cargo test` 全955テスト PASS
- [x] `cargo clippy -- -D warnings` 0 errors
- [x] `cargo fmt --check` 差分なし
- [x] `cargo run -- --lang rust .` self-dogfooding BLOCK 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)