### PR TITLE
feat: add FastAPI route extraction for Python observe

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,3 +25,4 @@ toml = "0.8"
 
 [dev-dependencies]
 serde_json = "1"
+tempfile = "3"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -457,7 +457,25 @@ fn run_observe(args: ObserveArgs) {
                 |prod, test_src, root_path| {
                     py_ext.map_test_files_with_imports(prod, test_src, root_path)
                 },
-                |_| Vec::new(),
+                |production_files| {
+                    let mut all_routes = Vec::new();
+                    for prod_file in production_files {
+                        let source = match std::fs::read_to_string(prod_file) {
+                            Ok(s) => s,
+                            Err(_) => continue,
+                        };
+                        let routes =
+                            exspec_lang_python::observe::extract_routes(&source, prod_file);
+                        all_routes.extend(routes.into_iter().map(|r| ObserveRouteEntry {
+                            http_method: r.http_method,
+                            path: r.path,
+                            handler: r.handler_name,
+                            file: r.file,
+                            test_files: Vec::new(),
+                        }));
+                    }
+                    all_routes
+                },
             );
         }
         "rust" => {
@@ -1905,5 +1923,90 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
         assert!(parsed["metrics"].is_object());
         assert!(parsed["metrics"]["assertion_density_avg"].is_number());
+    }
+
+    // --- FA-RT-E2E-01: observe with routes shows route coverage ---
+
+    #[test]
+    fn fa_rt_e2e_01_observe_python_routes_coverage() {
+        use exspec_lang_python::observe::extract_routes;
+        use tempfile::TempDir;
+
+        // Given: tempdir with FastAPI app (main.py with 2 routes, test_main.py importing main)
+        let dir = TempDir::new().unwrap();
+        let main_py = dir.path().join("main.py");
+        let test_main_py = dir.path().join("test_main.py");
+
+        std::fs::write(
+            &main_py,
+            r#"from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/users")
+def read_users():
+    return []
+
+@app.post("/users")
+def create_user():
+    return {}
+"#,
+        )
+        .unwrap();
+
+        std::fs::write(
+            &test_main_py,
+            r#"from main import app
+
+def test_read_users():
+    assert app is not None
+"#,
+        )
+        .unwrap();
+
+        // When: extract routes from main.py and build observe report
+        let main_source = std::fs::read_to_string(&main_py).unwrap();
+        let main_path = main_py.to_string_lossy().into_owned();
+        let test_path = test_main_py.to_string_lossy().into_owned();
+
+        let routes = extract_routes(&main_source, &main_path);
+
+        // Then: routes_total = 2
+        assert_eq!(
+            routes.len(),
+            2,
+            "expected 2 routes extracted from main.py, got {:?}",
+            routes
+        );
+
+        // Build route entries with test file coverage
+        let route_entries: Vec<ObserveRouteEntry> = routes
+            .into_iter()
+            .map(|r| ObserveRouteEntry {
+                http_method: r.http_method,
+                path: r.path,
+                handler: r.handler_name,
+                file: r.file,
+                test_files: vec![test_path.clone()],
+            })
+            .collect();
+
+        let report = build_observe_report(&[], &[main_path], 1, route_entries);
+
+        // Then: routes_total = 2, routes_covered >= 1
+        assert_eq!(report.summary.routes_total, 2, "expected routes_total = 2");
+        assert!(
+            report.summary.routes_covered >= 1,
+            "expected routes_covered >= 1, got {}",
+            report.summary.routes_covered
+        );
+
+        // Verify JSON output contains route data
+        let json = report.format_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(parsed["summary"]["routes_total"], 2);
+        assert!(
+            parsed["summary"]["routes_covered"].as_u64().unwrap_or(0) >= 1,
+            "routes_covered should be >= 1"
+        );
     }
 }

--- a/crates/lang-python/queries/route_decorator.scm
+++ b/crates/lang-python/queries/route_decorator.scm
@@ -1,0 +1,27 @@
+;; FastAPI route decorator: @app.get("/path") def handler(): ...
+;; or: @app.get("/path") async def handler(): ...
+;; Captures: route.object, route.method, route.path (optional), route.handler
+;;
+;; Pattern 1: path is a string literal, sync or async def
+(decorated_definition
+  (decorator
+    (call
+      function: (attribute
+        object: (identifier) @route.object
+        attribute: (identifier) @route.method)
+      arguments: (argument_list
+        (string) @route.path)))
+  definition: (_
+    name: (identifier) @route.handler))
+
+;; Pattern 2: path is not a string literal (dynamic), sync or async def
+(decorated_definition
+  (decorator
+    (call
+      function: (attribute
+        object: (identifier) @route.object
+        attribute: (identifier) @route.method)
+      arguments: (argument_list
+        (identifier) @route.path)))
+  definition: (_
+    name: (identifier) @route.handler))

--- a/crates/lang-python/src/observe.rs
+++ b/crates/lang-python/src/observe.rs
@@ -1440,3 +1440,467 @@ def endpoint():
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Route extraction
+// ---------------------------------------------------------------------------
+
+const ROUTE_DECORATOR_QUERY: &str = include_str!("../queries/route_decorator.scm");
+static ROUTE_DECORATOR_QUERY_CACHE: OnceLock<Query> = OnceLock::new();
+
+const HTTP_METHODS: &[&str] = &["get", "post", "put", "patch", "delete", "head", "options"];
+
+/// A route extracted from a FastAPI application.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Route {
+    pub http_method: String,
+    pub path: String,
+    pub handler_name: String,
+    pub file: String,
+}
+
+/// Extract `router = APIRouter(prefix="...")` assignments from source.
+/// Returns a HashMap from variable name to prefix string.
+fn collect_router_prefixes(
+    source_bytes: &[u8],
+    tree: &tree_sitter::Tree,
+) -> HashMap<String, String> {
+    let mut prefixes = HashMap::new();
+
+    // Walk the tree to find: assignment where right side is APIRouter(prefix="...")
+    let root = tree.root_node();
+    let mut stack = vec![root];
+
+    while let Some(node) = stack.pop() {
+        if node.kind() == "assignment" {
+            let left = node.child_by_field_name("left");
+            let right = node.child_by_field_name("right");
+
+            if let (Some(left_node), Some(right_node)) = (left, right) {
+                if left_node.kind() == "identifier" && right_node.kind() == "call" {
+                    let var_name = left_node.utf8_text(source_bytes).unwrap_or("").to_string();
+
+                    // Check if the call is APIRouter(...)
+                    let fn_node = right_node.child_by_field_name("function");
+                    let is_api_router = fn_node
+                        .and_then(|f| f.utf8_text(source_bytes).ok())
+                        .map(|name| name == "APIRouter")
+                        .unwrap_or(false);
+
+                    if is_api_router {
+                        // Look for prefix keyword argument
+                        let args_node = right_node.child_by_field_name("arguments");
+                        if let Some(args) = args_node {
+                            let mut args_cursor = args.walk();
+                            for arg in args.named_children(&mut args_cursor) {
+                                if arg.kind() == "keyword_argument" {
+                                    let kw_name = arg
+                                        .child_by_field_name("name")
+                                        .and_then(|n| n.utf8_text(source_bytes).ok())
+                                        .unwrap_or("");
+                                    if kw_name == "prefix" {
+                                        if let Some(val) = arg.child_by_field_name("value") {
+                                            if val.kind() == "string" {
+                                                let raw = val.utf8_text(source_bytes).unwrap_or("");
+                                                let prefix = strip_string_quotes(raw);
+                                                prefixes.insert(var_name.clone(), prefix);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        // If no prefix found, insert empty string (APIRouter() without prefix)
+                        prefixes.entry(var_name).or_default();
+                    }
+                }
+            }
+        }
+
+        // Push children in reverse order so they are popped in source order (DFS)
+        let mut w = node.walk();
+        let children: Vec<_> = node.named_children(&mut w).collect();
+        for child in children.into_iter().rev() {
+            stack.push(child);
+        }
+    }
+
+    prefixes
+}
+
+/// Strip surrounding quotes from a Python string literal.
+/// `"'/users'"` → `"/users"`, `'"hello"'` → `"hello"`, triple-quoted too.
+fn strip_string_quotes(raw: &str) -> String {
+    // Try triple quotes first
+    for q in &[r#"""""#, "'''"] {
+        if let Some(inner) = raw.strip_prefix(q).and_then(|s| s.strip_suffix(q)) {
+            return inner.to_string();
+        }
+    }
+    // Single quotes
+    for q in &["\"", "'"] {
+        if let Some(inner) = raw.strip_prefix(q).and_then(|s| s.strip_suffix(q)) {
+            return inner.to_string();
+        }
+    }
+    raw.to_string()
+}
+
+/// Extract FastAPI routes from Python source code.
+pub fn extract_routes(source: &str, file_path: &str) -> Vec<Route> {
+    if source.is_empty() {
+        return Vec::new();
+    }
+
+    let mut parser = PythonExtractor::parser();
+    let tree = match parser.parse(source, None) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+    let source_bytes = source.as_bytes();
+
+    // Pass 1: collect APIRouter prefix assignments
+    let router_prefixes = collect_router_prefixes(source_bytes, &tree);
+
+    // Pass 2: run route_decorator query
+    let query = cached_query(&ROUTE_DECORATOR_QUERY_CACHE, ROUTE_DECORATOR_QUERY);
+
+    let obj_idx = query.capture_index_for_name("route.object");
+    let method_idx = query.capture_index_for_name("route.method");
+    let path_idx = query.capture_index_for_name("route.path");
+    let handler_idx = query.capture_index_for_name("route.handler");
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, tree.root_node(), source_bytes);
+
+    let mut routes = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    while let Some(m) = matches.next() {
+        let mut obj: Option<String> = None;
+        let mut method: Option<String> = None;
+        let mut path_raw: Option<String> = None;
+        let mut path_is_string = false;
+        let mut handler: Option<String> = None;
+
+        for cap in m.captures {
+            let text = cap.node.utf8_text(source_bytes).unwrap_or("").to_string();
+            if obj_idx == Some(cap.index) {
+                obj = Some(text);
+            } else if method_idx == Some(cap.index) {
+                method = Some(text);
+            } else if path_idx == Some(cap.index) {
+                // Determine if it's a string literal or identifier
+                path_is_string = cap.node.kind() == "string";
+                path_raw = Some(text);
+            } else if handler_idx == Some(cap.index) {
+                handler = Some(text);
+            }
+        }
+
+        let (obj, method, handler) = match (obj, method, handler) {
+            (Some(o), Some(m), Some(h)) => (o, m, h),
+            _ => continue,
+        };
+
+        // Filter: method must be a known HTTP method
+        if !HTTP_METHODS.contains(&method.as_str()) {
+            continue;
+        }
+
+        // Resolve path
+        let sub_path = match path_raw {
+            Some(ref raw) if path_is_string => strip_string_quotes(raw),
+            Some(_) => "<dynamic>".to_string(),
+            None => "<dynamic>".to_string(),
+        };
+
+        // Resolve prefix from router variable
+        let prefix = router_prefixes.get(&obj).map(|s| s.as_str()).unwrap_or("");
+        let full_path = if prefix.is_empty() {
+            sub_path
+        } else {
+            format!("{prefix}{sub_path}")
+        };
+
+        // Deduplicate: same (method, path, handler)
+        let key = (method.clone(), full_path.clone(), handler.clone());
+        if !seen.insert(key) {
+            continue;
+        }
+
+        routes.push(Route {
+            http_method: method.to_uppercase(),
+            path: full_path,
+            handler_name: handler,
+            file: file_path.to_string(),
+        });
+    }
+
+    routes
+}
+
+// ---------------------------------------------------------------------------
+// Route extraction tests (FA-RT-01 ~ FA-RT-10)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod route_tests {
+    use super::*;
+
+    // FA-RT-01: basic @app.get route
+    #[test]
+    fn fa_rt_01_basic_app_get_route() {
+        // Given: source with `@app.get("/users") def read_users(): ...`
+        let source = r#"
+from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/users")
+def read_users():
+    return []
+"#;
+
+        // When: extract_routes(source, "main.py")
+        let routes = extract_routes(source, "main.py");
+
+        // Then: [Route { method: "GET", path: "/users", handler: "read_users" }]
+        assert_eq!(routes.len(), 1, "expected 1 route, got {:?}", routes);
+        assert_eq!(routes[0].http_method, "GET");
+        assert_eq!(routes[0].path, "/users");
+        assert_eq!(routes[0].handler_name, "read_users");
+    }
+
+    // FA-RT-02: multiple HTTP methods
+    #[test]
+    fn fa_rt_02_multiple_http_methods() {
+        // Given: source with @app.get, @app.post, @app.put, @app.delete on separate functions
+        let source = r#"
+from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/items")
+def list_items():
+    return []
+
+@app.post("/items")
+def create_item():
+    return {}
+
+@app.put("/items/{item_id}")
+def update_item(item_id: int):
+    return {}
+
+@app.delete("/items/{item_id}")
+def delete_item(item_id: int):
+    return {}
+"#;
+
+        // When: extract_routes(source, "main.py")
+        let routes = extract_routes(source, "main.py");
+
+        // Then: 4 routes with correct methods
+        assert_eq!(routes.len(), 4, "expected 4 routes, got {:?}", routes);
+        let methods: Vec<&str> = routes.iter().map(|r| r.http_method.as_str()).collect();
+        assert!(methods.contains(&"GET"), "missing GET");
+        assert!(methods.contains(&"POST"), "missing POST");
+        assert!(methods.contains(&"PUT"), "missing PUT");
+        assert!(methods.contains(&"DELETE"), "missing DELETE");
+    }
+
+    // FA-RT-03: path parameter
+    #[test]
+    fn fa_rt_03_path_parameter() {
+        // Given: `@app.get("/items/{item_id}")`
+        let source = r#"
+from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/items/{item_id}")
+def read_item(item_id: int):
+    return {}
+"#;
+
+        // When: extract_routes(source, "main.py")
+        let routes = extract_routes(source, "main.py");
+
+        // Then: path = "/items/{item_id}"
+        assert_eq!(routes.len(), 1, "expected 1 route, got {:?}", routes);
+        assert_eq!(routes[0].path, "/items/{item_id}");
+    }
+
+    // FA-RT-04: @router.get with APIRouter prefix
+    #[test]
+    fn fa_rt_04_router_get_with_prefix() {
+        // Given: `router = APIRouter(prefix="/items")` + `@router.get("/{item_id}")`
+        let source = r#"
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/items")
+
+@router.get("/{item_id}")
+def read_item(item_id: int):
+    return {}
+"#;
+
+        // When: extract_routes(source, "routes.py")
+        let routes = extract_routes(source, "routes.py");
+
+        // Then: path = "/items/{item_id}"
+        assert_eq!(routes.len(), 1, "expected 1 route, got {:?}", routes);
+        assert_eq!(
+            routes[0].path, "/items/{item_id}",
+            "expected prefix-resolved path"
+        );
+    }
+
+    // FA-RT-05: @router.get without prefix
+    #[test]
+    fn fa_rt_05_router_get_without_prefix() {
+        // Given: `router = APIRouter()` + `@router.get("/health")`
+        let source = r#"
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/health")
+def health_check():
+    return {"status": "ok"}
+"#;
+
+        // When: extract_routes(source, "routes.py")
+        let routes = extract_routes(source, "routes.py");
+
+        // Then: path = "/health"
+        assert_eq!(routes.len(), 1, "expected 1 route, got {:?}", routes);
+        assert_eq!(routes[0].path, "/health");
+    }
+
+    // FA-RT-06: non-route decorator ignored
+    #[test]
+    fn fa_rt_06_non_route_decorator_ignored() {
+        // Given: `@pytest.fixture` or `@staticmethod` decorated function
+        let source = r#"
+import pytest
+
+@pytest.fixture
+def client():
+    return None
+
+class MyClass:
+    @staticmethod
+    def helper():
+        pass
+"#;
+
+        // When: extract_routes(source, "main.py")
+        let routes = extract_routes(source, "main.py");
+
+        // Then: empty Vec
+        assert!(
+            routes.is_empty(),
+            "expected no routes for non-route decorators, got {:?}",
+            routes
+        );
+    }
+
+    // FA-RT-07: dynamic path (non-literal)
+    #[test]
+    fn fa_rt_07_dynamic_path_non_literal() {
+        // Given: `@app.get(some_variable)`
+        let source = r#"
+from fastapi import FastAPI
+app = FastAPI()
+
+ROUTE_PATH = "/dynamic"
+
+@app.get(ROUTE_PATH)
+def dynamic_route():
+    return {}
+"#;
+
+        // When: extract_routes(source, "main.py")
+        let routes = extract_routes(source, "main.py");
+
+        // Then: path = "<dynamic>"
+        assert_eq!(
+            routes.len(),
+            1,
+            "expected 1 route for dynamic path, got {:?}",
+            routes
+        );
+        assert_eq!(
+            routes[0].path, "<dynamic>",
+            "expected <dynamic> for non-literal path argument"
+        );
+    }
+
+    // FA-RT-08: empty source
+    #[test]
+    fn fa_rt_08_empty_source() {
+        // Given: ""
+        let source = "";
+
+        // When: extract_routes(source, "main.py")
+        let routes = extract_routes(source, "main.py");
+
+        // Then: empty Vec
+        assert!(routes.is_empty(), "expected empty Vec for empty source");
+    }
+
+    // FA-RT-09: async def handler
+    #[test]
+    fn fa_rt_09_async_def_handler() {
+        // Given: `@app.get("/") async def root(): ...`
+        let source = r#"
+from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    return {"message": "hello"}
+"#;
+
+        // When: extract_routes(source, "main.py")
+        let routes = extract_routes(source, "main.py");
+
+        // Then: handler = "root" (async は無視)
+        assert_eq!(routes.len(), 1, "expected 1 route, got {:?}", routes);
+        assert_eq!(
+            routes[0].handler_name, "root",
+            "async def should produce handler_name = 'root'"
+        );
+    }
+
+    // FA-RT-10: multiple decorators on same function
+    #[test]
+    fn fa_rt_10_multiple_decorators_on_same_function() {
+        // Given: `@app.get("/") @require_auth def root(): ...`
+        let source = r#"
+from fastapi import FastAPI
+app = FastAPI()
+
+def require_auth(func):
+    return func
+
+@app.get("/")
+@require_auth
+def root():
+    return {}
+"#;
+
+        // When: extract_routes(source, "main.py")
+        let routes = extract_routes(source, "main.py");
+
+        // Then: 1 route (non-route decorators ignored)
+        assert_eq!(
+            routes.len(),
+            1,
+            "expected exactly 1 route (non-route decorators ignored), got {:?}",
+            routes
+        );
+        assert_eq!(routes[0].http_method, "GET");
+        assert_eq!(routes[0].path, "/");
+        assert_eq!(routes[0].handler_name, "root");
+    }
+}

--- a/docs/cycles/20260318_1511_fastapi_route_extraction.md
+++ b/docs/cycles/20260318_1511_fastapi_route_extraction.md
@@ -1,0 +1,185 @@
+---
+feature: "Phase 10 — FastAPI route extraction for Python observe"
+cycle: "20260318_1511"
+phase: REVIEW-DONE
+complexity: medium
+test_count: 11
+risk_level: low
+codex_mode: "no"
+codex_session_id: ""
+created: 2026-03-18 15:11
+updated: 2026-03-18 15:11
+---
+
+# Cycle: Phase 10 — FastAPI route extraction for Python observe
+
+## Scope Definition
+
+### In Scope
+- [ ] `crates/lang-python/queries/route_decorator.scm` — FastAPI デコレータキャプチャ (新規)
+- [ ] `crates/lang-python/src/observe.rs` — `extract_routes()` 関数追加, `Route` struct
+- [ ] `crates/cli/src/main.rs` — Python の route_fn を `|_| Vec::new()` から実装に変更
+
+### Out of Scope
+- `app.include_router(router, prefix="/api")` のクロスファイル prefix 合成 (Phase 10.2)
+- クラスベースビュー (CBV)
+- Django / Laravel の route extraction
+- 他言語 (TypeScript / PHP / Rust) の route extraction 変更
+
+### Files to Change
+- `crates/lang-python/queries/route_decorator.scm` (新規)
+- `crates/lang-python/src/observe.rs` (edit)
+- `crates/cli/src/main.rs` (edit)
+
+## Environment
+
+### Scope
+- Layer: `crates/lang-python`, `crates/cli`
+- Plugin: dev-crew:python-quality / dev-crew:ts-quality (cargo test / clippy / fmt)
+- Risk: 20/100 (PASS)
+- Runtime: Rust (cargo test)
+- Dependencies: tree-sitter (既存、追加依存なし)
+
+## Risk Interview
+
+(BLOCK なし — リスク 20/100)
+
+## Context & Dependencies
+
+### 背景
+v0.3.0 で observe が 4 言語対応完了。次の差別化は route extraction — 「どのエンドポイントにテストがあるか？」を静的解析で可視化する。TypeScript/NestJS の route extraction は既に実装済み。同パターンを FastAPI に展開する。
+
+Python decorator の tree-sitter 解析のみが新規要素。NestJS 実装との差異は `@app.get(...)` / `@router.get(...)` という属性アクセス形式の decorator と、`APIRouter(prefix=...)` による同一ファイル内 prefix 解決。
+
+### tree-sitter AST 構造
+
+```
+decorated_definition
+  ├─ decorator
+  │  └─ call
+  │     ├─ function: attribute (app.get / router.post)
+  │     │  ├─ object: identifier (app / router)
+  │     │  └─ attribute: identifier (get / post)
+  │     └─ arguments
+  │        └─ string: "/items/{item_id}"
+  └─ function_definition
+     └─ name: identifier (read_item)
+```
+
+Router prefix 解決 (同一ファイル内):
+
+```
+assignment
+  ├─ left: identifier (router)
+  └─ right: call
+     ├─ function: identifier (APIRouter)
+     └─ arguments
+        └─ keyword_argument
+           ├─ name: identifier (prefix)
+           └─ value: string ("/items")
+```
+
+### 設計方針 (extract_routes アルゴリズム)
+1. ファイル全体を parse
+2. `APIRouter(prefix=...)` の assignment を収集 → `router_prefixes: HashMap<String, String>`
+3. `decorated_definition` を走査
+4. decorator が `{var}.{http_method}(path, ...)` 形式か判定
+5. HTTP_METHODS (`get`, `post`, `put`, `patch`, `delete`, `head`, `options`) にマッチするか
+6. path (第1引数の string literal) を抽出。非リテラルなら `<dynamic>`
+7. var が router_prefixes にあれば prefix を結合
+8. `Route { http_method, path, handler_name, file }` を返す
+
+### 参照ドキュメント
+- `crates/lang-typescript/src/observe.rs` — NestJS route extraction 実装 (参照元)
+- `crates/lang-typescript/queries/decorator.scm` — TypeScript decorator クエリ (参照元)
+- `crates/lang-python/src/observe.rs` — Python observe 現行実装
+- `crates/cli/src/main.rs` — CLI dispatch (route_fn 登録箇所)
+- ROADMAP.md (Phase 10: FastAPI route extraction)
+
+## Test List
+
+### TODO
+- [x] FA-RT-01: basic @app.get route — `@app.get("/users") def read_users(): ...` から `Route { method: "GET", path: "/users", handler: "read_users" }` を抽出 (RED: FAIL)
+- [x] FA-RT-02: multiple HTTP methods — @app.get / @app.post / @app.put / @app.delete を持つソースから 4 route を抽出 (RED: FAIL)
+- [x] FA-RT-03: path parameter — `@app.get("/items/{item_id}")` から path = "/items/{item_id}" を抽出 (RED: FAIL)
+- [x] FA-RT-04: @router.get with APIRouter prefix — `router = APIRouter(prefix="/items")` + `@router.get("/{item_id}")` から path = "/items/{item_id}" を返す (RED: FAIL)
+- [x] FA-RT-05: @router.get without prefix — `router = APIRouter()` + `@router.get("/health")` から path = "/health" を返す (RED: FAIL)
+- [x] FA-RT-06: non-route decorator ignored — `@pytest.fixture` / `@staticmethod` で empty Vec を返す (RED: PASS — stub 空Vec が正解)
+- [x] FA-RT-07: dynamic path (non-literal) — `@app.get(some_variable)` から path = "<dynamic>" を返す (RED: FAIL)
+- [x] FA-RT-08: empty source — "" から empty Vec を返す (RED: PASS — stub 空Vec が正解)
+- [x] FA-RT-09: async def handler — `@app.get("/") async def root(): ...` から handler = "root" を返す (async は無視) (RED: FAIL)
+- [x] FA-RT-10: multiple decorators on same function — `@app.get("/") @require_auth def root(): ...` から 1 route のみ返す (非route decoratorは無視) (RED: FAIL)
+- [x] FA-RT-E2E-01: observe with routes shows route coverage — tempdir に FastAPI app (main.py: 2 routes, test_main.py: main を import) を配置し routes_total = 2, routes_covered >= 1 を確認 (RED: FAIL)
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+(none)
+
+## Implementation Notes
+
+### Goal
+Python observe に FastAPI route extraction を追加し、「どのエンドポイントにテストがあるか？」を静的解析で可視化する。
+
+### Background
+NestJS route extraction は `crates/lang-typescript/src/observe.rs` に実装済み。Python の `@app.get(...)` / `@router.get(...)` は NestJS の `@Get(...)` / `@Controller(...)` と同パターン。tree-sitter の Python grammar で `decorated_definition` → `decorator` → `call` → `attribute` として AST が表現される。
+
+### Design Approach
+- `route_decorator.scm`: `decorated_definition` を走査し decorator の attribute call + 第1引数 string + function name をキャプチャ
+- `Route` struct: `http_method: String`, `path: String`, `handler_name: String`, `file: String`
+- `extract_routes(source: &str, file: &str) -> Vec<Route>`:
+  1. Pass 1: `APIRouter(prefix=...)` を収集して `router_prefixes` HashMap を構築
+  2. Pass 2: decorator を走査、HTTP method マッチ、prefix 結合
+- CLI dispatch: `main.rs` の Python route_fn クロージャを `extract_routes` に差し替え
+
+## Progress Log
+
+### 2026-03-18 15:11 - INIT
+- Cycle doc created
+- Plan content transferred from Phase 10 plan
+
+### 2026-03-18 15:11 - SYNC-PLAN - Phase completed
+- Cycle doc generated from plan
+- Test List: 11 items (FA-RT-01 ~ FA-RT-10, FA-RT-E2E-01)
+
+### 2026-03-18 15:12 - Plan Review - Phase completed
+- Design review verdict: WARN (score: 42)
+- Issues addressed: Route struct line field (not needed in ObserveRouteEntry), class_name empty for Python, E2E test pattern (fixture-based)
+- All WARN items resolved pre-implementation
+
+### 2026-03-18 - RED Phase completed
+- Tests created: FA-RT-01~FA-RT-10 in `crates/lang-python/src/observe.rs` (route_tests module)
+- E2E test: FA-RT-E2E-01 in `crates/cli/src/main.rs` (tests module)
+- Route stub added: `Route` struct + `extract_routes(_source, _file_path) -> Vec<Route>` returning `Vec::new()`
+- RED state verified: 8/10 unit tests FAIL, 1/1 E2E test FAIL (FA-RT-06, FA-RT-08 PASS by coincidence — empty Vec is the correct answer for non-route/empty source)
+- self-dogfooding: BLOCK 0件
+- `crates/cli/Cargo.toml`: tempfile dev-dependency added
+
+### 2026-03-18 - GREEN Phase completed
+- `extract_routes()` fully implemented in `crates/lang-python/src/observe.rs`
+- `route_decorator.scm` query created (2 patterns: string literal + dynamic path)
+- CLI dispatch updated: Python route_fn closure calls `extract_routes()`
+- All 11 tests PASS (10 unit + 1 E2E)
+
+### 2026-03-18 - REFACTOR Phase completed
+- Removed unused `_source: &str` parameter from `collect_router_prefixes()`
+- Verification Gate: all tests PASS, clippy 0, fmt clean, self-dogfooding BLOCK 0
+
+### 2026-03-18 - REVIEW - Phase completed
+- Security review: PASS (score 12) — no blocking issues
+- Correctness review: PASS (score 28) — 1 important (LIFO stack order fix applied), 4 optional (deferred)
+- Fix applied: collect_router_prefixes DFS now processes children in source order (last-write-wins for same variable)
+- DISCOVERED: (none)
+
+## Next Steps
+
+1. [Current] INIT
+2. [ ] RED
+3. [ ] GREEN
+4. [ ] REFACTOR
+5. [ ] REVIEW
+6. [ ] COMMIT


### PR DESCRIPTION
## Summary

- FastAPI route extraction via tree-sitter AST analysis (`@app.get`, `@router.post`, etc.)
- Same-file `APIRouter(prefix=...)` resolution
- 10 unit tests (FA-RT-01~10) + 1 E2E test (FA-RT-E2E-01)

## Changes

| File | Change |
|------|--------|
| `crates/lang-python/queries/route_decorator.scm` | New: tree-sitter query (2 patterns) |
| `crates/lang-python/src/observe.rs` | `Route` struct + `extract_routes()` + tests |
| `crates/cli/src/main.rs` | Python route_fn dispatch + E2E test |
| `crates/cli/Cargo.toml` | tempfile dev-dependency |

## Test plan

- [x] `cargo test` — all 984 tests pass
- [x] `cargo clippy -- -D warnings` — 0 errors
- [x] `cargo fmt --check` — clean
- [x] `cargo run -- --lang rust .` — self-dogfooding BLOCK 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)