### PR TITLE
fix: Phase 13 review findings (tests + docs)

### DIFF
--- a/crates/lang-python/src/observe.rs
+++ b/crates/lang-python/src/observe.rs
@@ -1422,6 +1422,19 @@ def endpoint():
     }
 
     // -----------------------------------------------------------------------
+    // PY-STEM-12: __foo__.py -> strip_prefix + strip_suffix (double underscore prefix)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn py_stem_12_production_stem_dunder_prefix_and_suffix() {
+        // Given: production file path "pkg/__foo__.py"
+        // When: production_stem() is called
+        // Then: returns Some("_foo") (strip_prefix('_') -> "_foo__", strip_suffix("__") -> "_foo")
+        let extractor = PythonExtractor::new();
+        let result = extractor.production_stem("pkg/__foo__.py");
+        assert_eq!(result, Some("_foo"));
+    }
+
+    // -----------------------------------------------------------------------
     // PY-SRCLAYOUT-01: src/ layout absolute import resolved
     // -----------------------------------------------------------------------
     #[test]
@@ -1561,10 +1574,11 @@ def endpoint():
             "models/cars.py not found in mappings: {:?}",
             result
         );
+        let cars_m = cars_mapping.unwrap();
         assert!(
-            cars_mapping.unwrap().test_files.contains(&test_path),
+            cars_m.test_files.contains(&test_path),
             "test_mixed.py not mapped to models/cars.py via absolute import: {:?}",
-            cars_mapping.unwrap().test_files
+            cars_m.test_files
         );
 
         // Then: tests/helpers.py is mapped via relative import (Layer 2)
@@ -1574,10 +1588,41 @@ def endpoint():
             "tests/helpers.py not found in mappings: {:?}",
             result
         );
+        let helpers_m = helpers_mapping.unwrap();
         assert!(
-            helpers_mapping.unwrap().test_files.contains(&test_path),
+            helpers_m.test_files.contains(&test_path),
             "test_mixed.py not mapped to tests/helpers.py via relative import: {:?}",
-            helpers_mapping.unwrap().test_files
+            helpers_m.test_files
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PY-REL-01: `from .. import X` bare two-dot relative import
+    // -----------------------------------------------------------------------
+    #[test]
+    fn py_rel_01_bare_two_dot_relative_import() {
+        // Given: `from .. import utils` in pkg/sub/test_thing.py,
+        //        pkg/utils.py exists (parent of parent)
+        let r = run_import_test(
+            "pkg/utils.py",
+            "def helper():\n    pass\n",
+            "pkg/sub/test_thing.py",
+            "from .. import utils\n\ndef test_thing():\n    pass\n",
+            &[],
+        );
+
+        // Then: pkg/utils.py is mapped via bare relative import (is_bare_relative=true path)
+        let mapping = r.mappings.iter().find(|m| m.production_file == r.prod_path);
+        assert!(
+            mapping.is_some(),
+            "pkg/utils.py not found in mappings: {:?}",
+            r.mappings
+        );
+        let mapping = mapping.unwrap();
+        assert!(
+            mapping.test_files.contains(&r.test_path),
+            "test_thing.py not in test_files for pkg/utils.py via bare two-dot import: {:?}",
+            mapping.test_files
         );
     }
 }

--- a/docs/known-constraints.md
+++ b/docs/known-constraints.md
@@ -66,6 +66,15 @@ def test_benchmark_performance(benchmark):
     benchmark(my_function)
 ```
 
+## Python observe: src/ layout fallback
+
+Python observe's Layer 2 (import tracing) supports the standard `src/` layout (`src/package/module.py`). When an absolute import like `from package.module import X` cannot be resolved under the scan root directly, exspec falls back to `<scan_root>/src/` as a second candidate.
+
+**Limitations:**
+
+- Only `src/` at depth 1 is supported. Non-standard layouts like `source/`, `lib/`, or nested `src/src/` are not detected.
+- The fallback is tried after the direct resolution, so if both `package/module.py` and `src/package/module.py` exist, the direct resolution wins.
+
 ## Callback / wrapper patterns
 
 Tests that pass assertions through callbacks (e.g. `done()` in Mocha-style async tests) or return assertion wrappers may not be recognized:


### PR DESCRIPTION
## Summary

- PY-STEM-12: `__foo__.py` の production_stem テスト追加 (correctness review 指摘)
- PY-REL-01: `from .. import X` bare two-dot relative import の e2e テスト追加
- PY-ABS-05: unwrap() 二重呼び出しを変数束縛に修正
- src/ layout fallback の制約を known-constraints.md に記載

## Test plan

- [x] `cargo test -p exspec-lang-python` (181 tests pass, +2)
- [x] `cargo clippy -- -D warnings` (0 warnings)
- [x] `cargo fmt --check` (clean)
- [x] `cargo run -- --lang rust .` (BLOCK 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)