### PR TITLE
feat: Python observe L2 barrel wildcard re-export

### DIFF
--- a/crates/lang-python/queries/re_export.scm
+++ b/crates/lang-python/queries/re_export.scm
@@ -1,9 +1,15 @@
 ;; Re-export patterns in __init__.py:
 ;;   from .module import Foo
 ;;   from .module import Foo, Bar
+;;   from .module import *
 
 ;; Named re-export: from .module import Symbol
 (import_from_statement
   module_name: (_) @from_specifier
   name: (dotted_name
     (identifier) @symbol_name))
+
+;; Wildcard re-export: from .module import *
+(import_from_statement
+  module_name: (_) @from_specifier
+  (wildcard_import) @wildcard)

--- a/crates/lang-python/src/observe.rs
+++ b/crates/lang-python/src/observe.rs
@@ -336,40 +336,59 @@ impl ObserveExtractor for PythonExtractor {
             .capture_index_for_name("from_specifier")
             .expect("@from_specifier capture not found in re_export.scm");
         let symbol_name_idx = query.capture_index_for_name("symbol_name");
+        let wildcard_idx = query.capture_index_for_name("wildcard");
 
         let mut cursor = QueryCursor::new();
         let mut matches = cursor.matches(query, tree.root_node(), source_bytes);
 
-        // Group symbols by from_specifier
-        let mut grouped: HashMap<String, Vec<String>> = HashMap::new();
+        // Group symbols by from_specifier, tracking wildcard flag separately
+        struct ReExportEntry {
+            symbols: Vec<String>,
+            wildcard: bool,
+        }
+        let mut grouped: HashMap<String, ReExportEntry> = HashMap::new();
 
         while let Some(m) = matches.next() {
             let mut from_spec: Option<String> = None;
             let mut sym: Option<String> = None;
+            let mut is_wildcard = false;
 
             for cap in m.captures {
                 if cap.index == from_specifier_idx {
                     let raw = cap.node.utf8_text(source_bytes).unwrap_or("").to_string();
                     from_spec = Some(python_module_to_relative_specifier(&raw));
+                } else if wildcard_idx == Some(cap.index) {
+                    is_wildcard = true;
                 } else if symbol_name_idx == Some(cap.index) {
                     sym = Some(cap.node.utf8_text(source_bytes).unwrap_or("").to_string());
                 }
             }
 
-            if let (Some(spec), Some(symbol)) = (from_spec, sym) {
+            if let Some(spec) = from_spec {
                 // Only include relative re-exports
                 if spec.starts_with("./") || spec.starts_with("../") {
-                    grouped.entry(spec).or_default().push(symbol);
+                    let entry = grouped.entry(spec).or_insert(ReExportEntry {
+                        symbols: Vec::new(),
+                        wildcard: false,
+                    });
+                    if is_wildcard {
+                        entry.wildcard = true;
+                    }
+                    if let Some(symbol) = sym {
+                        if !entry.symbols.contains(&symbol) {
+                            entry.symbols.push(symbol);
+                        }
+                    }
                 }
             }
         }
 
         grouped
             .into_iter()
-            .map(|(from_specifier, symbols)| BarrelReExport {
-                symbols,
+            .map(|(from_specifier, entry)| BarrelReExport {
+                symbols: entry.symbols,
                 from_specifier,
-                wildcard: false,
+                wildcard: entry.wildcard,
                 namespace_wildcard: false,
             })
             .collect()
@@ -1068,6 +1087,230 @@ def endpoint():
             !result,
             "expected file_exports_any_symbol to return false for Bar"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // PY-BARREL-05: `from .module import *` extracts wildcard=true
+    // -----------------------------------------------------------------------
+    #[test]
+    fn py_barrel_05_re_export_wildcard() {
+        // Given: __init__.py content with a wildcard re-export
+        let source = "from .module import *\n";
+
+        // When: extract_barrel_re_exports is called
+        let extractor = PythonExtractor::new();
+        let result = extractor.extract_barrel_re_exports(source, "__init__.py");
+
+        // Then: one entry with wildcard=true, from_specifier="./module", empty symbols
+        let entry = result.iter().find(|e| e.from_specifier == "./module");
+        assert!(entry.is_some(), "./module not found in {:?}", result);
+        let entry = entry.unwrap();
+        assert!(entry.wildcard, "expected wildcard=true, got {:?}", entry);
+        assert!(
+            entry.symbols.is_empty(),
+            "expected empty symbols for wildcard, got {:?}",
+            entry.symbols
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PY-BARREL-06: `from .module import Foo, Bar` extracts named (wildcard=false)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn py_barrel_06_re_export_named_multi_symbol() {
+        // Given: __init__.py content with multiple named re-exports
+        let source = "from .module import Foo, Bar\n";
+
+        // When: extract_barrel_re_exports is called
+        let extractor = PythonExtractor::new();
+        let result = extractor.extract_barrel_re_exports(source, "__init__.py");
+
+        // Then: one entry with wildcard=false, symbols=["Foo", "Bar"]
+        let entry = result.iter().find(|e| e.from_specifier == "./module");
+        assert!(entry.is_some(), "./module not found in {:?}", result);
+        let entry = entry.unwrap();
+        assert!(
+            !entry.wildcard,
+            "expected wildcard=false for named re-export, got {:?}",
+            entry
+        );
+        assert!(
+            entry.symbols.contains(&"Foo".to_string()),
+            "Foo not in symbols: {:?}",
+            entry.symbols
+        );
+        assert!(
+            entry.symbols.contains(&"Bar".to_string()),
+            "Bar not in symbols: {:?}",
+            entry.symbols
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PY-BARREL-07: e2e: wildcard barrel resolves imported symbol
+    // test imports `from pkg import Foo`, pkg/__init__.py has `from .module import *`,
+    // pkg/module.py defines Foo → mapped
+    // -----------------------------------------------------------------------
+    #[test]
+    fn py_barrel_07_e2e_wildcard_barrel_mapped() {
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let pkg = dir.path().join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+
+        // pkg/__init__.py: wildcard re-export
+        std::fs::write(pkg.join("__init__.py"), "from .module import *\n").unwrap();
+        // pkg/module.py: defines Foo
+        std::fs::write(pkg.join("module.py"), "class Foo:\n    pass\n").unwrap();
+        // tests/test_foo.py: imports from pkg
+        let tests_dir = dir.path().join("tests");
+        std::fs::create_dir_all(&tests_dir).unwrap();
+        std::fs::write(
+            tests_dir.join("test_foo.py"),
+            "from pkg import Foo\n\ndef test_foo():\n    assert Foo()\n",
+        )
+        .unwrap();
+
+        let extractor = PythonExtractor::new();
+        let module_path = pkg.join("module.py").to_string_lossy().into_owned();
+        let test_path = tests_dir.join("test_foo.py").to_string_lossy().into_owned();
+        let test_source = std::fs::read_to_string(&test_path).unwrap();
+
+        let production_files = vec![module_path.clone()];
+        let test_sources: HashMap<String, String> =
+            [(test_path.clone(), test_source)].into_iter().collect();
+
+        // When: map_test_files_with_imports
+        let result =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+
+        // Then: module.py is matched to test_foo.py via barrel chain
+        let mapping = result.iter().find(|m| m.production_file == module_path);
+        assert!(
+            mapping.is_some(),
+            "module.py not found in mappings: {:?}",
+            result
+        );
+        let mapping = mapping.unwrap();
+        assert!(
+            mapping.test_files.contains(&test_path),
+            "test_foo.py not matched to module.py: {:?}",
+            mapping.test_files
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PY-BARREL-08: e2e: named barrel resolves imported symbol
+    // test imports `from pkg import Foo`, pkg/__init__.py has `from .module import Foo`,
+    // pkg/module.py defines Foo → mapped
+    // -----------------------------------------------------------------------
+    #[test]
+    fn py_barrel_08_e2e_named_barrel_mapped() {
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let pkg = dir.path().join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+
+        // pkg/__init__.py: named re-export
+        std::fs::write(pkg.join("__init__.py"), "from .module import Foo\n").unwrap();
+        // pkg/module.py: defines Foo
+        std::fs::write(pkg.join("module.py"), "class Foo:\n    pass\n").unwrap();
+        // tests/test_foo.py: imports from pkg
+        let tests_dir = dir.path().join("tests");
+        std::fs::create_dir_all(&tests_dir).unwrap();
+        std::fs::write(
+            tests_dir.join("test_foo.py"),
+            "from pkg import Foo\n\ndef test_foo():\n    assert Foo()\n",
+        )
+        .unwrap();
+
+        let extractor = PythonExtractor::new();
+        let module_path = pkg.join("module.py").to_string_lossy().into_owned();
+        let test_path = tests_dir.join("test_foo.py").to_string_lossy().into_owned();
+        let test_source = std::fs::read_to_string(&test_path).unwrap();
+
+        let production_files = vec![module_path.clone()];
+        let test_sources: HashMap<String, String> =
+            [(test_path.clone(), test_source)].into_iter().collect();
+
+        // When: map_test_files_with_imports
+        let result =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+
+        // Then: module.py is matched to test_foo.py via barrel chain
+        let mapping = result.iter().find(|m| m.production_file == module_path);
+        assert!(
+            mapping.is_some(),
+            "module.py not found in mappings: {:?}",
+            result
+        );
+        let mapping = mapping.unwrap();
+        assert!(
+            mapping.test_files.contains(&test_path),
+            "test_foo.py not matched to module.py: {:?}",
+            mapping.test_files
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PY-BARREL-09: e2e: wildcard barrel does NOT map non-exported symbol
+    // test imports `from pkg import NonExistent`, pkg/__init__.py has `from .module import *`,
+    // pkg/module.py has __all__ = ["Foo"] (does NOT export NonExistent) → NOT mapped
+    // -----------------------------------------------------------------------
+    #[test]
+    fn py_barrel_09_e2e_wildcard_barrel_non_exported_not_mapped() {
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let pkg = dir.path().join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+
+        // pkg/__init__.py: wildcard re-export
+        std::fs::write(pkg.join("__init__.py"), "from .module import *\n").unwrap();
+        // pkg/module.py: __all__ explicitly limits exports to Foo only
+        std::fs::write(
+            pkg.join("module.py"),
+            "__all__ = [\"Foo\"]\n\nclass Foo:\n    pass\n\nclass NonExistent:\n    pass\n",
+        )
+        .unwrap();
+        // tests/test_nonexistent.py: imports NonExistent from pkg
+        let tests_dir = dir.path().join("tests");
+        std::fs::create_dir_all(&tests_dir).unwrap();
+        std::fs::write(
+            tests_dir.join("test_nonexistent.py"),
+            "from pkg import NonExistent\n\ndef test_ne():\n    assert NonExistent()\n",
+        )
+        .unwrap();
+
+        let extractor = PythonExtractor::new();
+        let module_path = pkg.join("module.py").to_string_lossy().into_owned();
+        let test_path = tests_dir
+            .join("test_nonexistent.py")
+            .to_string_lossy()
+            .into_owned();
+        let test_source = std::fs::read_to_string(&test_path).unwrap();
+
+        let production_files = vec![module_path.clone()];
+        let test_sources: HashMap<String, String> =
+            [(test_path.clone(), test_source)].into_iter().collect();
+
+        // When: map_test_files_with_imports
+        let result =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+
+        // Then: module.py is NOT matched to test_nonexistent.py
+        // (NonExistent is not exported by module.py)
+        let mapping = result.iter().find(|m| m.production_file == module_path);
+        if let Some(mapping) = mapping {
+            assert!(
+                !mapping.test_files.contains(&test_path),
+                "test_nonexistent.py should NOT be matched to module.py: {:?}",
+                mapping.test_files
+            );
+        }
+        // If no mapping found for module.py at all, that's also correct
     }
 
     // -----------------------------------------------------------------------

--- a/docs/cycles/20260319_0829_python-observe-l2-barrel-import.md
+++ b/docs/cycles/20260319_0829_python-observe-l2-barrel-import.md
@@ -1,0 +1,114 @@
+---
+feature: "Phase 14 — Python observe L2 barrel import resolution"
+cycle: "20260319_0829"
+phase: RED
+complexity: standard
+test_count: 5
+risk_level: medium
+codex_session_id: ""
+created: 2026-03-19 08:29
+updated: 2026-03-19 08:29
+---
+
+# Cycle: Phase 14 — Python observe L2 barrel import resolution
+
+## Scope Definition
+
+### In Scope
+- `re_export.scm` に wildcard import pattern 追加 (`from .module import *`)
+- `extract_barrel_re_exports()` で wildcard フラグを正しく設定
+- テスト追加 (barrel wildcard / barrel named multi-symbol / e2e)
+- httpx + Requests 再 dogfooding で改善確認
+
+### Out of Scope
+- L1 cross-directory matching (別 Issue)
+- Multi-path CLI (別 Issue)
+- `namespace_wildcard` (Python に該当する構文なし)
+
+### Files to Change
+- `crates/lang-python/queries/re_export.scm`
+- `crates/lang-python/src/observe.rs`
+
+## Environment
+
+### Scope
+- Layer: `crates/lang-python/queries/re_export.scm`, `crates/lang-python/src/observe.rs`
+- Plugin: dev-crew:python-quality は不使用 (Rust crate)
+- Risk: 35/100 (WARN)
+- Runtime: Rust (cargo test)
+- Dependencies: tree-sitter (既存、追加依存なし)
+
+### Risk Interview
+
+(WARN — リスク 35/100)
+- wildcard pattern 追加による FP: `re_export.scm` に新規 capture `@wildcard` を追加するため、既存 named import との干渉を確認が必要
+- `extract_barrel_re_exports()` の wildcard 検出: capture index が正しく取得されることを unit test で確認
+- core インフラは既に統合済みのため、Python 側の query + extraction 修正のみで完結する想定
+
+## Context & Dependencies
+
+### Background
+
+Phase 12 dogfooding で httpx の 28 FN の原因が `__init__.py` barrel import 未解決と判明。`import httpx` や `from httpx import Client` が `httpx/__init__.py` の re-export を追跡できていない。
+
+Phase 13 で P0 (L1 `_` prefix, src/ layout) は修正済み。本フェーズは P1 の最大影響タスク。
+
+根本原因:
+1. wildcard import (`from ._api import *`) を検出できない (re_export.scm に pattern なし)
+2. `wildcard: false` をハードコード
+
+core の `resolve_barrel_exports`, `collect_import_matches`, `file_exports_any_symbol` は既に統合済みで動作する。Python 側の query + extraction が不完全なだけ。
+
+### Real-world Patterns
+
+- **httpx `__init__.py`**: `from ._api import *` (wildcard 9件)
+- **requests `__init__.py`**: `from .api import delete, get, head, ...` (named multi-symbol)
+
+### Design Approach
+
+**1. re_export.scm 変更**
+
+```scheme
+;; Wildcard re-export: from .module import *
+(import_from_statement
+  module_name: (_) @from_specifier
+  (wildcard_import) @wildcard)
+```
+
+**2. extract_barrel_re_exports() 変更**
+
+- `@wildcard` capture index を取得
+- match 内で wildcard capture を検出したら `is_wildcard = true`
+- `BarrelReExport` の `wildcard` フィールドを正しく設定
+- wildcard の場合は symbols は空 Vec
+
+**3. 既存インフラの動作確認**
+
+core の `resolve_barrel_exports_inner()` は wildcard: true なら全 re-export を追跡。Python 側の `file_exports_any_symbol()` は既に実装済み。
+
+## Test List
+
+### TODO
+(none)
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+- [x] PY-BARREL-05: `from .module import *` が wildcard=true で抽出される
+- [x] PY-BARREL-06: `from .module import Foo, Bar` が named (wildcard=false) で抽出される
+- [x] PY-BARREL-07: e2e: test imports `from pkg import Foo`, `pkg/__init__.py` has `from .module import *`, `pkg/module.py` has Foo → mapped
+- [x] PY-BARREL-08: e2e: test imports `from pkg import Foo`, `pkg/__init__.py` has `from .module import Foo` (named) → mapped
+- [x] PY-BARREL-09: e2e: `from pkg import NonExistent`, `pkg/__init__.py` has `from .module import *`, module has `__all__=["Foo"]` → NOT mapped
+(none)
+
+## Progress Log
+
+### 2026-03-19 08:29 — Cycle doc 作成 (sync-plan)
+
+planファイルから Cycle doc を生成。
+Phase 12 dogfooding で判明した httpx の 28 FN の根本原因 (barrel import 未解決) を修正するサイクルを開始。
+test_count: 5 (unit: 2, e2e: 3)


### PR DESCRIPTION
## Summary
- Python `re_export.scm` に wildcard import pattern (`from .module import *`) を追加
- `extract_barrel_re_exports()` で `@wildcard` capture を検出し `BarrelReExport.wildcard = true` を設定
- テスト5件追加 (PY-BARREL-05~09: unit 2 + e2e 3)

## Dogfooding Results
| Project | Before | After |
|---------|--------|-------|
| requests | 0% mapped | 55.6% mapped |
| httpx | 6.9% | 10.3% (package name resolution は #116 で対応) |

## Test plan
- [x] PY-BARREL-05: wildcard=true で抽出される
- [x] PY-BARREL-06: named multi-symbol が wildcard=false で抽出される
- [x] PY-BARREL-07: e2e wildcard barrel → mapped
- [x] PY-BARREL-08: e2e named barrel → mapped
- [x] PY-BARREL-09: e2e wildcard + `__all__` filter → NOT mapped
- [x] cargo test / clippy / fmt / self-dogfooding 全 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)