### PR TITLE
feat: ai-prompt output format with fix guidance

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -11,7 +11,8 @@ use exspec_core::observe_report::{
     ObserveFileEntry, ObserveReport, ObserveRouteEntry, ObserveSummary,
 };
 use exspec_core::output::{
-    compute_exit_code, filter_by_severity, format_json, format_sarif, format_terminal, SummaryStats,
+    compute_exit_code, filter_by_severity, format_ai_prompt, format_json, format_sarif,
+    format_terminal, SummaryStats,
 };
 use exspec_core::rules::{
     evaluate_file_rules, evaluate_project_rules, evaluate_rules, Config, Severity,
@@ -40,7 +41,7 @@ pub struct LintArgs {
     pub path: String,
 
     /// Output format
-    #[arg(long, default_value = "terminal")]
+    #[arg(long, default_value = "ai-prompt")]
     pub format: String,
 
     /// Language filter (python, typescript, php, rust)
@@ -245,7 +246,7 @@ fn load_config(config_path: &str) -> Config {
 }
 
 const SUPPORTED_LANGUAGES: &[&str] = &["python", "typescript", "php", "rust"];
-const SUPPORTED_FORMATS: &[&str] = &["terminal", "json", "sarif"];
+const SUPPORTED_FORMATS: &[&str] = &["terminal", "json", "sarif", "ai-prompt"];
 
 fn validate_format(format: &str) -> Result<(), String> {
     if !SUPPORTED_FORMATS.contains(&format) {
@@ -635,7 +636,14 @@ fn run_lint(lint: LintArgs) {
             )
         }
         "sarif" => format_sarif(&display_diagnostics),
-        _ => format_terminal(
+        "terminal" => format_terminal(
+            &display_diagnostics,
+            test_file_count,
+            all_functions.len(),
+            &metrics,
+            &hints,
+        ),
+        _ => format_ai_prompt(
             &display_diagnostics,
             test_file_count,
             all_functions.len(),
@@ -1904,10 +1912,30 @@ mod tests {
         assert!(err.contains("sarif"), "should list supported: {err}");
     }
 
+    // --- AI-FMT-07: CLI default format is "ai-prompt" ---
+
     #[test]
-    fn validate_format_ai_prompt_error() {
-        let err = validate_format("ai-prompt").unwrap_err();
-        assert!(err.contains("ai-prompt"));
+    fn validate_format_ai_prompt_ok() {
+        // Given: format = "ai-prompt"
+        // When: validate_format("ai-prompt") を呼ぶ
+        // Then: Ok(()) が返る
+        assert!(
+            validate_format("ai-prompt").is_ok(),
+            "ai-prompt should be a valid format"
+        );
+    }
+
+    #[test]
+    fn cli_default_format_is_ai_prompt() {
+        // Given: --format オプションなし
+        // When: CLI を parse_lint で解析
+        // Then: format フィールドのデフォルトが "ai-prompt"
+        let lint = parse_lint(&["exspec", "."]);
+        assert_eq!(
+            lint.format, "ai-prompt",
+            "default format should be ai-prompt, got: {}",
+            lint.format
+        );
     }
 
     // --- E2E: SARIF output ---

--- a/crates/core/src/output.rs
+++ b/crates/core/src/output.rs
@@ -9,6 +9,7 @@ pub enum OutputFormat {
     Terminal,
     Json,
     Sarif,
+    AiPrompt,
 }
 
 /// Count unique violated functions by (file, line) pairs.
@@ -177,6 +178,7 @@ struct RuleMeta {
     id: &'static str,
     name: &'static str,
     short_description: &'static str,
+    guidance: &'static str,
 }
 
 const RULE_REGISTRY: &[RuleMeta] = &[
@@ -184,86 +186,103 @@ const RULE_REGISTRY: &[RuleMeta] = &[
         id: "T001",
         name: "assertion-free",
         short_description: "Test function has no assertions",
+        guidance: "This test does not express a specification -- it only verifies \"no crash.\" Ask: what observable outcome should this function guarantee? Assert the return value, state change, or side effect instead.",
     },
     RuleMeta {
         id: "T002",
         name: "mock-overuse",
         short_description: "Test function uses too many mocks",
+        guidance: "Too many mocks can make the test fragile and coupled to implementation. Consider using fewer mocks and testing through real collaborators where possible. Extract the core logic into a pure function that can be tested without mocks.",
     },
     RuleMeta {
         id: "T003",
         name: "giant-test",
         short_description: "Test function exceeds line count threshold",
+        guidance: "A large test is hard to understand and maintain. Split it into smaller, focused tests -- each verifying one behavior. Use helper functions or parameterized tests to reduce repetition.",
     },
     RuleMeta {
         id: "T004",
         name: "no-parameterized",
         short_description: "Low ratio of parameterized tests",
+        guidance: "Repeated tests with different inputs can be consolidated using parameterized/table-driven tests. This improves coverage while reducing code volume and making the test suite easier to extend.",
     },
     RuleMeta {
         id: "T005",
         name: "pbt-missing",
         short_description: "No property-based testing library imported",
+        guidance: "Property-based testing (PBT) can find edge cases that example-based tests miss. Consider adding a PBT library (e.g., Hypothesis, fast-check, proptest) for functions with wide input domains.",
     },
     RuleMeta {
         id: "T006",
         name: "low-assertion-density",
         short_description: "Low assertion count per test function",
+        guidance: "A test with few assertions may not fully verify the behavior under test. Ensure the test checks all relevant aspects of the output -- return values, state changes, and side effects.",
     },
     RuleMeta {
         id: "T007",
         name: "test-source-ratio",
         short_description: "Test file to source file ratio",
+        guidance: "The test-to-source file ratio is outside the expected range. Consider whether test files are missing for some source modules, or whether test files are over-concentrated.",
     },
     RuleMeta {
         id: "T008",
         name: "no-contract",
         short_description: "No contract testing library used in tests",
+        guidance: "Contract tests verify that API boundaries (HTTP, message queues, etc.) behave as agreed. Consider adding a contract testing library (e.g., Pact) if this project has service-to-service communication.",
     },
     RuleMeta {
         id: "T101",
         name: "how-not-what",
         short_description: "Test verifies implementation rather than behavior",
+        guidance: "This test accesses private/internal members, coupling it to implementation details. Test the public interface instead -- assert on observable outputs rather than internal state.",
     },
     RuleMeta {
         id: "T102",
         name: "fixture-sprawl",
         short_description: "Test depends on too many fixtures",
+        guidance: "This test depends on many fixtures, making it hard to understand what is actually being tested. Reduce fixture dependencies by inlining setup or using builder patterns.",
     },
     RuleMeta {
         id: "T103",
         name: "missing-error-test",
         short_description: "No error/exception test found in file",
+        guidance: "No test verifies error/exception behavior in this file. Add tests for invalid inputs, boundary conditions, and expected failure modes.",
     },
     RuleMeta {
         id: "T105",
         name: "deterministic-no-metamorphic",
         short_description: "All assertions use exact equality, no relational checks",
+        guidance: "All assertions use exact equality (==). Consider adding relational assertions (>, <, contains, matches) to express behavioral properties rather than specific outputs.",
     },
     RuleMeta {
         id: "T106",
         name: "duplicate-literal-assertion",
         short_description: "Same literal appears multiple times in assertions",
+        guidance: "The same literal value appears in multiple assertions, creating a maintenance burden. Extract it into a named constant or verify the underlying relationship instead.",
     },
     RuleMeta {
         id: "T107",
         name: "assertion-roulette",
         short_description: "Multiple assertions without failure messages",
+        guidance: "Multiple assertions without descriptive messages make failures hard to diagnose. Add a failure message to each assertion explaining what was expected and why.",
     },
     RuleMeta {
         id: "T108",
         name: "wait-and-see",
         short_description: "Test uses sleep/delay causing flaky tests",
+        guidance: "Using sleep/delay in tests causes flakiness and slow execution. Use polling with timeouts, event-based synchronization, or dependency injection to control timing.",
     },
     RuleMeta {
         id: "T109",
         name: "undescriptive-test-name",
         short_description: "Test name does not describe behavior",
+        guidance: "The test name does not describe the expected behavior. Rename it to follow the pattern: given_[context]_when_[action]_then_[outcome] or a similar descriptive convention.",
     },
     RuleMeta {
         id: "T110",
         name: "skip-only-test",
         short_description: "Test skips or marks incomplete without assertions",
+        guidance: "This test is skipped or marked incomplete without assertions. Either implement the test or remove the skip marker. Dead test code erodes trust in the suite.",
     },
 ];
 
@@ -331,6 +350,105 @@ pub fn format_sarif(diagnostics: &[Diagnostic]) -> String {
         .build();
 
     serde_json::to_string_pretty(&sarif_doc).unwrap_or_else(|_| "{}".to_string())
+}
+
+pub fn format_ai_prompt(
+    diagnostics: &[Diagnostic],
+    file_count: usize,
+    function_count: usize,
+    metrics: &ProjectMetrics,
+    hints: &[Hint],
+) -> String {
+    let _ = (file_count, metrics, hints);
+
+    let block_count = diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Block)
+        .count();
+    let warn_count = diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Warn)
+        .count();
+    let info_count = diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Info)
+        .count();
+    let violated = count_violated_functions(diagnostics);
+    let pass_count = function_count.saturating_sub(violated);
+
+    let mut lines = Vec::new();
+    lines.push("# exspec -- Test Quality Report".to_string());
+    lines.push(String::new());
+
+    // BLOCK section
+    let block_diags: Vec<&Diagnostic> = diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Block)
+        .collect();
+    if !block_diags.is_empty() {
+        lines.push("## BLOCK (must fix)".to_string());
+        lines.push(String::new());
+        for d in block_diags {
+            let line_str = d.line.map(|l| format!(":{l}")).unwrap_or_default();
+            lines.push(format!("### {}{}", d.file, line_str));
+            lines.push(String::new());
+            lines.push(format!("**{}**: {}", d.rule, d.message));
+            lines.push(String::new());
+            if let Some(meta) = RULE_REGISTRY.iter().find(|m| m.id == d.rule.0) {
+                for guidance_line in meta.guidance.lines() {
+                    lines.push(format!("> {guidance_line}"));
+                }
+                lines.push(String::new());
+            }
+        }
+    }
+
+    // WARN section
+    let warn_diags: Vec<&Diagnostic> = diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Warn)
+        .collect();
+    if !warn_diags.is_empty() {
+        lines.push("## WARN (should fix)".to_string());
+        lines.push(String::new());
+        for d in warn_diags {
+            let line_str = d.line.map(|l| format!(":{l}")).unwrap_or_default();
+            lines.push(format!("### {}{}", d.file, line_str));
+            lines.push(String::new());
+            lines.push(format!("**{}**: {}", d.rule, d.message));
+            lines.push(String::new());
+            if let Some(meta) = RULE_REGISTRY.iter().find(|m| m.id == d.rule.0) {
+                for guidance_line in meta.guidance.lines() {
+                    lines.push(format!("> {guidance_line}"));
+                }
+                lines.push(String::new());
+            }
+        }
+    }
+
+    // INFO section
+    let info_diags: Vec<&Diagnostic> = diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Info)
+        .collect();
+    if !info_diags.is_empty() {
+        lines.push("## INFO (consider)".to_string());
+        lines.push(String::new());
+        for d in info_diags {
+            let line_str = d.line.map(|l| format!(":{l}")).unwrap_or_default();
+            lines.push(format!(
+                "- {}{} {}: {}",
+                d.file, line_str, d.rule, d.message
+            ));
+        }
+        lines.push(String::new());
+    }
+
+    lines.push(format!(
+        "Score: BLOCK {block_count} | WARN {warn_count} | INFO {info_count} | PASS {pass_count}",
+    ));
+
+    lines.join("\n")
 }
 
 /// Filter diagnostics to only include those at or above the given minimum severity.
@@ -917,6 +1035,166 @@ mod tests {
         assert_eq!(
             parsed["runs"][0]["invocations"][0]["executionSuccessful"],
             true
+        );
+    }
+
+    // --- AI-FMT-01: BLOCK diagnostic with guidance ---
+
+    #[test]
+    fn ai_prompt_block_has_section_and_guidance() {
+        // Given: T001 (assertion-free) の BLOCK diagnostic 1件
+        let diag = block_diag();
+        // When: format_ai_prompt() を呼ぶ
+        let output = format_ai_prompt(&[diag], 1, 1, &ProjectMetrics::default(), &[]);
+        // Then: "## BLOCK" セクション、file:line + rule + message、guidance (blockquote `>`) が含まれる
+        assert!(
+            output.contains("## BLOCK"),
+            "should contain BLOCK section: {output}"
+        );
+        assert!(
+            output.contains("test.py:10"),
+            "should contain file:line: {output}"
+        );
+        assert!(output.contains("T001"), "should contain rule id: {output}");
+        assert!(
+            output.contains("assertion-free"),
+            "should contain rule name in message: {output}"
+        );
+        let has_blockquote = output.lines().any(|l| l.starts_with('>'));
+        assert!(
+            has_blockquote,
+            "should contain guidance blockquote: {output}"
+        );
+    }
+
+    // --- AI-FMT-02: WARN diagnostic with guidance ---
+
+    #[test]
+    fn ai_prompt_warn_has_section_and_guidance() {
+        // Given: T003 (giant-test) の WARN diagnostic 1件
+        let diag = warn_diag();
+        // When: format_ai_prompt() を呼ぶ
+        let output = format_ai_prompt(&[diag], 1, 1, &ProjectMetrics::default(), &[]);
+        // Then: "## WARN" セクション、diagnostic、guidance が含まれる
+        assert!(
+            output.contains("## WARN"),
+            "should contain WARN section: {output}"
+        );
+        assert!(
+            output.contains("test.py:5"),
+            "should contain file:line: {output}"
+        );
+        assert!(output.contains("T003"), "should contain rule id: {output}");
+        let has_blockquote = output.lines().any(|l| l.starts_with('>'));
+        assert!(
+            has_blockquote,
+            "should contain guidance blockquote: {output}"
+        );
+    }
+
+    // --- AI-FMT-03: INFO diagnostic without guidance ---
+
+    #[test]
+    fn ai_prompt_info_has_section_no_guidance() {
+        // Given: T005 (pbt-missing) の INFO diagnostic 1件
+        let diag = info_diag();
+        // When: format_ai_prompt() を呼ぶ
+        let output = format_ai_prompt(&[diag], 1, 1, &ProjectMetrics::default(), &[]);
+        // Then: "## INFO" セクション、`- ` で始まる1行表示、blockquote (`>`) なし
+        assert!(
+            output.contains("## INFO"),
+            "should contain INFO section: {output}"
+        );
+        let has_bullet = output.lines().any(|l| l.starts_with("- "));
+        assert!(
+            has_bullet,
+            "INFO items should use bullet `- ` format: {output}"
+        );
+        let has_blockquote = output.lines().any(|l| l.starts_with('>'));
+        assert!(
+            !has_blockquote,
+            "INFO should NOT contain guidance blockquote: {output}"
+        );
+    }
+
+    // --- AI-FMT-04: Mixed severities grouped correctly ---
+
+    #[test]
+    fn ai_prompt_mixed_severities_ordered_block_warn_info() {
+        // Given: BLOCK + WARN + INFO の3件
+        let diags = [block_diag(), warn_diag(), info_diag()];
+        // When: format_ai_prompt() を呼ぶ
+        let output = format_ai_prompt(&diags, 1, 3, &ProjectMetrics::default(), &[]);
+        // Then: "## BLOCK" < "## WARN" < "## INFO" の順序
+        let block_pos = output.find("## BLOCK").expect("## BLOCK not found");
+        let warn_pos = output.find("## WARN").expect("## WARN not found");
+        let info_pos = output.find("## INFO").expect("## INFO not found");
+        assert!(
+            block_pos < warn_pos,
+            "## BLOCK should appear before ## WARN"
+        );
+        assert!(warn_pos < info_pos, "## WARN should appear before ## INFO");
+    }
+
+    // --- AI-FMT-05: Empty diagnostics ---
+
+    #[test]
+    fn ai_prompt_empty_has_header_and_score_no_sections() {
+        // Given: 空の diagnostics
+        // When: format_ai_prompt() を呼ぶ
+        let output = format_ai_prompt(&[], 0, 0, &ProjectMetrics::default(), &[]);
+        // Then: "# exspec" ヘッダーと "Score:" 行が含まれ、"## BLOCK/WARN/INFO" は含まれない
+        assert!(
+            output.contains("# exspec"),
+            "should contain # exspec header: {output}"
+        );
+        assert!(
+            output.contains("Score:"),
+            "should contain Score: line: {output}"
+        );
+        assert!(
+            !output.contains("## BLOCK"),
+            "empty result should not contain ## BLOCK: {output}"
+        );
+        assert!(
+            !output.contains("## WARN"),
+            "empty result should not contain ## WARN: {output}"
+        );
+        assert!(
+            !output.contains("## INFO"),
+            "empty result should not contain ## INFO: {output}"
+        );
+    }
+
+    // --- AI-FMT-06: All rules have non-empty guidance ---
+
+    #[test]
+    fn all_rules_have_non_empty_guidance() {
+        // Given: RULE_REGISTRY の全エントリ
+        // When: 各 guidance を検査
+        // Then: 全て空文字列でない
+        for meta in RULE_REGISTRY {
+            assert!(
+                !meta.guidance.is_empty(),
+                "rule {} ({}) should have non-empty guidance",
+                meta.id,
+                meta.name
+            );
+        }
+    }
+
+    // --- AI-FMT-08: Score line present ---
+
+    #[test]
+    fn ai_prompt_score_line_reflects_counts() {
+        // Given: BLOCK 1件 + WARN 1件 の diagnostics
+        let diags = [block_diag(), warn_diag()];
+        // When: format_ai_prompt() を呼ぶ
+        let output = format_ai_prompt(&diags, 1, 2, &ProjectMetrics::default(), &[]);
+        // Then: "Score: BLOCK 1 | WARN 1" を含む行が存在
+        assert!(
+            output.contains("Score: BLOCK 1 | WARN 1"),
+            "should contain score summary: {output}"
         );
     }
 }

--- a/docs/cycles/20260319_1400_ai-prompt-format.md
+++ b/docs/cycles/20260319_1400_ai-prompt-format.md
@@ -1,0 +1,163 @@
+---
+feature: "Phase 17 — ai-prompt output format with fix guidance"
+cycle: "20260319_1400"
+phase: RED-DONE
+complexity: standard
+test_count: 8
+risk_level: low
+codex_session_id: ""
+created: 2026-03-19 14:00
+updated: 2026-03-19 14:00
+---
+
+# Cycle: Phase 17 — ai-prompt output format with fix guidance
+
+## Scope Definition
+
+### In Scope
+- `RuleMeta` に `guidance: &'static str` フィールド追加
+- 全17ルール (`T001`〜`T110`) の guidance 文字列記述
+- `format_ai_prompt()` 実装 (BLOCK/WARN はセクション分け + guidance、INFO は1行表示)
+- `OutputFormat::AiPrompt` variant 追加
+- CLI `--format` デフォルトを `"terminal"` → `"ai-prompt"` に変更
+- `SUPPORTED_FORMATS` に `"ai-prompt"` 追加、match アーム追加
+
+### Out of Scope
+- `format_ai_prompt` の国際化 (英語のみ)
+- guidance のカスタマイズ (.exspec.toml 経由) — 別 Issue
+- `observe` サブコマンドへの ai-prompt 対応 — 別 Issue
+
+### Files to Change
+- `crates/core/src/output.rs`
+- `crates/cli/src/main.rs`
+
+## Environment
+
+### Scope
+- Layer: `crates/core/src/output.rs`, `crates/cli/src/main.rs`
+- Plugin: dev-crew:rust-quality (cargo test)
+- Risk: 25/100 (WARN)
+- Runtime: Rust (cargo test)
+- Dependencies: 既存依存のみ (追加なし)
+
+### Risk Interview
+
+(WARN — リスク 25/100)
+- `--format` デフォルト変更は breaking change の性質を持つが、`--format terminal` で従来動作を維持可能。後方互換は保たれる。
+- `RULE_REGISTRY` への `guidance` フィールド追加はコンパイルエラーを起こす可能性があるが、影響は `output.rs` 内に限定される。
+- `format_ai_prompt()` の出力形式はテキスト文字列であり、JSON/SARIF のようなスキーマ制約なし。設計自由度が高い反面、テストでの文字列検証が主となる。
+- regression リスク: 既存の `format_terminal`/`format_json`/`format_sarif` に変更なし。SARIF の `RULE_REGISTRY` 参照は `guidance` フィールドを使わないため影響なし。
+
+## Context & Dependencies
+
+### Background
+
+exspec の主要ユーザーは AI agent (Claude Code 等)。現在のデフォルト出力 `terminal` は人間向けの1行メッセージで、AI が「なぜ問題なのか」「どう直すべきか」を理解できない。
+
+AI が自律的にテスト品質を改善できるよう、ルールごとの修正ガイダンス付き `ai-prompt` フォーマットを実装し、デフォルトにする。
+
+### Design Approach
+
+**1. RuleMeta に guidance フィールド追加**
+
+```rust
+struct RuleMeta {
+    id: &'static str,
+    name: &'static str,
+    short_description: &'static str,
+    guidance: &'static str,  // 追加
+}
+```
+
+全17ルールに guidance を記述。空文字は AI-FMT-06 でブロックされる。
+
+**2. format_ai_prompt() の出力構造**
+
+```
+# exspec ai-prompt report
+
+Score: BLOCK {n} | WARN {n} | INFO {n} | PASS {n}
+
+## BLOCK
+
+### {file}:{line} [{rule}] {message}
+{guidance}
+
+## WARN
+
+### {file}:{line} [{rule}] {message}
+{guidance}
+
+## INFO
+
+- {file}:{line} [{rule}] {message}
+```
+
+- BLOCK / WARN はセクション分けし、guidance を付与
+- INFO は1行表示 (guidance なし) — ノイズ削減
+- 空 diagnostics の場合はヘッダー + Score のみ
+
+**3. CLI デフォルト変更**
+
+```rust
+// before
+#[arg(long, default_value = "terminal")]
+pub format: String,
+
+// after
+#[arg(long, default_value = "ai-prompt")]
+pub format: String,
+```
+
+`SUPPORTED_FORMATS` (`validate_format` テスト) に `"ai-prompt"` を追加。
+
+**4. 既存コードとの整合性**
+
+- `OutputFormat` enum に `AiPrompt` variant を追加。既存 `Terminal`/`Json`/`Sarif` に並列
+- `format_sarif()` は `RULE_REGISTRY` を `short_description` のみで参照 → `guidance` 追加で影響なし
+- `format_terminal()`/`format_json()` に変更なし
+
+## Test List
+
+### TODO
+(none)
+
+### WIP
+- [x] AI-FMT-01: `format_ai_prompt` with BLOCK diagnostic → "## BLOCK" セクションに diagnostic + guidance が含まれる
+- [x] AI-FMT-02: `format_ai_prompt` with WARN diagnostic → "## WARN" セクションに diagnostic + guidance が含まれる
+- [x] AI-FMT-03: `format_ai_prompt` with INFO diagnostic → 1行表示、guidance なし
+- [x] AI-FMT-04: `format_ai_prompt` with mixed severities → BLOCK, WARN, INFO の順にグルーピング
+- [x] AI-FMT-05: `format_ai_prompt` with empty diagnostics → ヘッダー + Score のみ
+- [x] AI-FMT-06: `RULE_REGISTRY` の全ルールが空でない `guidance` を持つ
+- [x] AI-FMT-07: CLI default format が "ai-prompt" (validate_format テスト更新)
+- [x] AI-FMT-08: `format_ai_prompt` に Score 行が含まれる
+
+### DISCOVERED
+(none)
+
+### DONE
+(none)
+
+## Progress Log
+
+### 2026-03-19 — RED phase 完了
+
+全8テストケース (AI-FMT-01〜08) を作成。
+
+- `crates/core/src/output.rs` の mod tests に AI-FMT-01〜06, 08 を追加
+  - `format_ai_prompt` 未実装により 7エラー（コンパイルエラー）
+  - `RuleMeta.guidance` フィールド未定義によりコンパイルエラー
+- `crates/cli/src/main.rs` の mod tests を更新 (AI-FMT-07)
+  - `validate_format_ai_prompt_error` → `validate_format_ai_prompt_ok` に書き換え
+  - `cli_default_format_is_ai_prompt` テストを追加
+  - 両テスト失敗（FAILED）を確認 → RED state verified
+
+### 2026-03-19 14:00 — Cycle doc 作成 (sync-plan)
+
+planファイルから Cycle doc を生成。
+AI agent (Claude Code 等) が exspec の出力を直接消費してテスト品質を改善できるよう、
+ルールごとの修正ガイダンス付き `ai-prompt` フォーマットを実装するサイクルを開始。
+変更対象: `crates/core/src/output.rs` (RuleMeta guidance 追加・format_ai_prompt 実装)、
+`crates/cli/src/main.rs` (デフォルト変更)。
+test_count: 8 (unit: 8)
+Design Review Gate: PASS (スコア 20/100)


### PR DESCRIPTION
## Summary

- Add `ai-prompt` output format as the new CLI default for `exspec check`
- Each diagnostic includes rule-specific guidance (why it's a problem + how to fix)
- BLOCK/WARN sections with blockquote guidance, INFO as one-liners
- All 17 rules have guidance text

## Test plan

- [x] 8 new tests (AI-FMT-01~08) all passing
- [x] cargo clippy / fmt / self-dogfooding clean
- [x] `--format terminal` still works for human-readable output

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)