### PR TITLE
test: add PY-HELPER-11 for singular test/ directory case

### DIFF
--- a/crates/lang-python/src/observe.rs
+++ b/crates/lang-python/src/observe.rs
@@ -1256,6 +1256,18 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // PY-HELPER-11: test/helpers.py -> helper (test/ singular directory)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn py_helper_11_test_singular_dir_helper() {
+        // Given: file is test/helpers.py (singular "test" directory, not "tests")
+        // When: is_non_sut_helper is called
+        // Then: returns true (segment check matches both "tests" and "test")
+        let extractor = PythonExtractor::new();
+        assert!(extractor.is_non_sut_helper("test/helpers.py", true));
+    }
+
+    // -----------------------------------------------------------------------
     // PY-BARREL-01: __init__.py -> is_barrel_file = true
     // -----------------------------------------------------------------------
     #[test]


### PR DESCRIPTION
## Summary
- Add explicit test for `test/` (singular) directory case per Codex review feedback
- Implementation already handled both `tests/` and `test/` but lacked a pinning test

## Test plan
- [x] PY-HELPER-11: test/helpers.py returns true
- [x] 224 tests pass