### PR TITLE
docs: Phase 22 re-dogfood results

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ Dogfooded across 11 projects (~40k tests):
 | laravel | PHP | 11,044 | 222 | helper delegation |
 | symfony | PHP | 17,204 | 616 | helper delegation |
 | ripgrep | Rust | 16 | 0 | ~330 tests in macros (not detected) |
-| tokio | Rust | 1,594 | 385 | custom assert macros |
-| clap | Rust | 1,455 | 193 | helper delegation |
+| tokio | Rust | 1,594 | 257 | select! token_tree |
+| clap | Rust | 1,455 | 71 | helper delegation |
 | django | Python | 1,048 | 22 | helper delegation |
 
 Full results: [docs/dogfooding-results.md](docs/dogfooding-results.md)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,7 @@
 
 ## Current Phase
 
-v0.4.x development. Phase 22: Rust custom assert macro auto-detection (`assert_*!` macro invocations as assertions). Expected impact: tokio -124 FP, clap -115 FP. Next: Phase 23 helper delegation (1-hop assertion tracing).
+v0.4.x development. Phase 22 DONE: Rust custom assert macro auto-detection. Actual impact: tokio BLOCK 385→257 (-128), clap BLOCK 193→71 (-122). Next: Phase 23 helper delegation (1-hop assertion tracing).
 
 observe TypeScript: P=100%, R=91% (stable). Python: P=98.2%, R=96.8% (stable). Route extraction for 4 frameworks. Lint: 17 active rules, 4 languages, 11 projects / ~40k tests dogfooded. Default output: ai-prompt (with fix guidance).
 

--- a/docs/dogfooding-results.md
+++ b/docs/dogfooding-results.md
@@ -1,9 +1,9 @@
 # Dogfooding Results
 
-Latest: 2026-03-19, exspec v0.3.0 (commit 908b531)
+Latest: 2026-03-23, exspec v0.4.x (Phase 22: Rust custom assert macro auto-detection)
 Initial: 2026-03-09, exspec v0.1.0 (commit 5957cd0)
 
-## Summary (v0.3.0)
+## Summary (v0.4.x, Phase 22)
 
 | Project | Lang | Tests | BLOCK | WARN | INFO | PASS | Primary BLOCK Cause |
 |---------|------|-------|-------|------|------|------|---------------------|
@@ -16,8 +16,17 @@ Initial: 2026-03-09, exspec v0.1.0 (commit 5957cd0)
 | laravel | PHP | 11044 | 222 | 179 | 10564 | 3887 | helper delegation |
 | symfony | PHP | 17204 | 616 | 319 | 14653 | 10146 | helper delegation, addToAssertionCount |
 | ripgrep | Rust | 16 | 0 | 2 | 30 | 1 | ~330 tests in `rgtest!` macro not detected |
-| tokio | Rust | 1594 | 385 | 96 | 1875 | 532 | custom assert macros, select! token_tree |
-| clap | Rust | 1455 | 193 | 60 | 908 | 797 | helper delegation |
+| tokio | Rust | 1594 | **257** | 80 | 2069 | 494 | select! token_tree, smoke tests |
+| clap | Rust | 1455 | **71** | 53 | 956 | 863 | helper delegation, smoke tests |
+
+### v0.3.0 → v0.4.x BLOCK changes (Phase 22)
+
+| Project | v0.3.0 BLOCK | v0.4.x BLOCK | Delta | Notes |
+|---------|-------------|-------------|-------|-------|
+| tokio | 385 | 257 | **-128** | `assert_*!` macro auto-detection |
+| clap | 193 | 71 | **-122** | `assert_*!` macro auto-detection |
+
+Phase 22 impact: **-250 BLOCK** across 2 Rust projects. Custom assertion macros (`assert_pending!`, `assert_ready!`, `assert_data_eq!`, etc.) now auto-detected via prefix matching.
 
 ### v0.1.0 → v0.3.0 BLOCK changes
 


### PR DESCRIPTION
## Summary

- tokio BLOCK 385→257 (-128)
- clap BLOCK 193→71 (-122)
- Total -250 BLOCK from Rust custom assert macro auto-detection (Phase 22)

## Test plan

- [x] Dogfooded on latest tokio and clap
- [x] Results documented in dogfooding-results.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)