### PR TITLE
feat: add stem collision guard to Python observe (#126)

### DIFF
--- a/crates/lang-python/src/observe.rs
+++ b/crates/lang-python/src/observe.rs
@@ -872,8 +872,8 @@ impl PythonExtractor {
             .collect();
 
         // Layer 1 extension: stem-only fallback (cross-directory match)
-        // For test files that L1 core did not match, attempt stem-only match against all prod files.
-        // This handles the httpx-like case where tests/ and pkg/ are in different directories.
+        // For test files that L1 core did not match, attempt stem-only match against prod files.
+        // Stem collision guard: if multiple prod files share the same stem, defer to L2 import tracing.
         {
             // Build stem -> list of production indices (stem stripped of leading `_`)
             let mut stem_to_prod_indices: HashMap<String, Vec<usize>> = HashMap::new();
@@ -899,6 +899,9 @@ impl PythonExtractor {
                 }
                 if let Some(tstem) = self.test_stem(test_file) {
                     if let Some(prod_indices) = stem_to_prod_indices.get(tstem) {
+                        if prod_indices.len() > 1 {
+                            continue; // stem collision: defer to L2 import tracing
+                        }
                         for &idx in prod_indices {
                             if !mappings[idx].test_files.contains(test_file) {
                                 mappings[idx].test_files.push(test_file.clone());
@@ -4098,17 +4101,18 @@ def test_user_detail():
     }
 
     // -----------------------------------------------------------------------
-    // PY-L1X-04: stem ambiguity: same stem in multiple prod files -> mapped to all
+    // PY-L1X-04: stem collision -- no imports -> L1 stem-only fallback defers to L2
     //
-    // When multiple prod files share the same stem, recall takes priority:
-    // all matching prod files should include the test.
+    // When multiple prod files share the same stem and the test has no imports,
+    // the collision guard prevents L1 stem-only from mapping to any of them.
+    // Precision takes priority over recall in this case.
     // -----------------------------------------------------------------------
     #[test]
-    fn py_l1x_04_stem_ambiguity_maps_to_all() {
+    fn py_l1x_04_stem_collision_defers_to_l2() {
         use tempfile::TempDir;
 
         // Given: pkg/client.py, pkg/aio/client.py, and tests/test_client.py (no imports)
-        //        Both have stem "client"; test has stem "client" -> should map to both
+        //        Both have stem "client"; test has stem "client" but no import -> collision guard fires
         let dir = TempDir::new().unwrap();
         let pkg = dir.path().join("pkg");
         let pkg_aio = pkg.join("aio");
@@ -4120,7 +4124,7 @@ def test_user_detail():
         std::fs::write(pkg.join("client.py"), "class Client:\n    pass\n").unwrap();
         std::fs::write(pkg_aio.join("client.py"), "class AsyncClient:\n    pass\n").unwrap();
 
-        // No imports -- forces reliance on stem-only fallback
+        // No imports -- collision guard should prevent stem-only fallback from mapping
         let test_content = "def test_client():\n    pass\n";
         std::fs::write(tests_dir.join("test_client.py"), test_content).unwrap();
 
@@ -4141,16 +4145,15 @@ def test_user_detail():
         let result =
             extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
 
-        // Then: test_client.py is mapped to BOTH pkg/client.py and pkg/aio/client.py
-        //       (recall priority: all matching stems are included)
+        // Then: test_client.py is NOT mapped to pkg/client.py (collision guard defers to L2)
         let client_mapped = result
             .iter()
             .find(|m| m.production_file == client_path)
             .map(|m| m.test_files.contains(&test_path))
             .unwrap_or(false);
         assert!(
-            client_mapped,
-            "test_client.py should be mapped to pkg/client.py (stem ambiguity -> all). mappings={:?}",
+            !client_mapped,
+            "test_client.py should NOT be mapped to pkg/client.py (stem collision -> defer to L2). mappings={:?}",
             result
         );
 
@@ -4160,8 +4163,8 @@ def test_user_detail():
             .map(|m| m.test_files.contains(&test_path))
             .unwrap_or(false);
         assert!(
-            aio_mapped,
-            "test_client.py should be mapped to pkg/aio/client.py (stem ambiguity -> all). mappings={:?}",
+            !aio_mapped,
+            "test_client.py should NOT be mapped to pkg/aio/client.py (stem collision -> defer to L2). mappings={:?}",
             result
         );
     }
@@ -4228,6 +4231,159 @@ def test_user_detail():
         assert!(
             pkg_not_mapped,
             "pkg/client.py should NOT be mapped (L1 core match suppresses stem-only fallback). mappings={:?}",
+            result
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PY-L1X-06: stem collision + L2 import -> maps to the correct file via ImportTracing
+    //
+    // When multiple prod files share the same stem, stem-only fallback defers to L2.
+    // If the test has a direct import, L2 resolves it to the correct file.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn py_l1x_06_stem_collision_with_l2_import_resolves_correctly() {
+        use std::collections::HashMap;
+        use tempfile::TempDir;
+
+        // Given: pkg/client.py, pkg/aio/client.py (same stem "client")
+        //        tests/test_client.py has "from pkg.client import Client" (direct import)
+        let dir = TempDir::new().unwrap();
+        let pkg = dir.path().join("pkg");
+        let pkg_aio = pkg.join("aio");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::create_dir_all(&pkg_aio).unwrap();
+        let tests_dir = dir.path().join("tests");
+        std::fs::create_dir_all(&tests_dir).unwrap();
+
+        std::fs::write(pkg.join("client.py"), "class Client:\n    pass\n").unwrap();
+        std::fs::write(pkg_aio.join("client.py"), "class AsyncClient:\n    pass\n").unwrap();
+
+        // Direct import to pkg.client -> L2 resolves to pkg/client.py
+        let test_content =
+            "from pkg.client import Client\n\ndef test_client():\n    assert Client()\n";
+        std::fs::write(tests_dir.join("test_client.py"), test_content).unwrap();
+
+        let client_path = pkg.join("client.py").to_string_lossy().into_owned();
+        let aio_client_path = pkg_aio.join("client.py").to_string_lossy().into_owned();
+        let test_path = tests_dir
+            .join("test_client.py")
+            .to_string_lossy()
+            .into_owned();
+
+        let extractor = PythonExtractor::new();
+        let production_files = vec![client_path.clone(), aio_client_path.clone()];
+        let test_sources: HashMap<String, String> = [(test_path.clone(), test_content.to_string())]
+            .into_iter()
+            .collect();
+
+        // When: map_test_files_with_imports is called
+        let result =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+
+        // Then: test_client.py is mapped to pkg/client.py only (L2 ImportTracing)
+        let client_mapping = result.iter().find(|m| m.production_file == client_path);
+        assert!(
+            client_mapping.is_some(),
+            "pkg/client.py not found in mappings: {:?}",
+            result
+        );
+        let client_mapping = client_mapping.unwrap();
+        assert!(
+            client_mapping.test_files.contains(&test_path),
+            "test_client.py should be mapped to pkg/client.py via L2. mappings={:?}",
+            result
+        );
+        assert_eq!(
+            client_mapping.strategy,
+            MappingStrategy::ImportTracing,
+            "strategy should be ImportTracing (L2), got {:?}",
+            client_mapping.strategy
+        );
+
+        // Then: pkg/aio/client.py is NOT mapped (collision guard + L2 resolves to pkg/client.py)
+        let aio_mapped = result
+            .iter()
+            .find(|m| m.production_file == aio_client_path)
+            .map(|m| m.test_files.contains(&test_path))
+            .unwrap_or(false);
+        assert!(
+            !aio_mapped,
+            "test_client.py should NOT be mapped to pkg/aio/client.py. mappings={:?}",
+            result
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PY-L1X-07: stem collision + barrel import -> L2 barrel resolves to correct file
+    //
+    // When multiple prod files share the same stem, and the test imports via barrel,
+    // L2 barrel tracing resolves to the correct file (not all files with that stem).
+    // -----------------------------------------------------------------------
+    #[test]
+    fn py_l1x_07_stem_collision_with_barrel_import_resolves_correctly() {
+        use std::collections::HashMap;
+        use tempfile::TempDir;
+
+        // Given: pkg/__init__.py (barrel: "from .client import Client")
+        //        pkg/client.py, pkg/aio/client.py (same stem "client")
+        //        tests/test_client.py has "from pkg import Client" (barrel import)
+        let dir = TempDir::new().unwrap();
+        let pkg = dir.path().join("pkg");
+        let pkg_aio = pkg.join("aio");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::create_dir_all(&pkg_aio).unwrap();
+        let tests_dir = dir.path().join("tests");
+        std::fs::create_dir_all(&tests_dir).unwrap();
+
+        // Barrel re-exports Client from pkg/client.py (not pkg/aio/client.py)
+        std::fs::write(pkg.join("__init__.py"), "from .client import Client\n").unwrap();
+        std::fs::write(pkg.join("client.py"), "class Client:\n    pass\n").unwrap();
+        std::fs::write(pkg_aio.join("client.py"), "class AsyncClient:\n    pass\n").unwrap();
+
+        // Import via barrel -> L2 barrel tracing should resolve to pkg/client.py
+        let test_content = "from pkg import Client\n\ndef test_client():\n    assert Client()\n";
+        std::fs::write(tests_dir.join("test_client.py"), test_content).unwrap();
+
+        let client_path = pkg.join("client.py").to_string_lossy().into_owned();
+        let aio_client_path = pkg_aio.join("client.py").to_string_lossy().into_owned();
+        let test_path = tests_dir
+            .join("test_client.py")
+            .to_string_lossy()
+            .into_owned();
+
+        let extractor = PythonExtractor::new();
+        let production_files = vec![client_path.clone(), aio_client_path.clone()];
+        let test_sources: HashMap<String, String> = [(test_path.clone(), test_content.to_string())]
+            .into_iter()
+            .collect();
+
+        // When: map_test_files_with_imports is called
+        let result =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+
+        // Then: collision guard prevents L1 stem-only from mapping to both files
+        //       L2 barrel import resolves to pkg/client.py (via __init__.py re-export)
+        let client_mapped = result
+            .iter()
+            .find(|m| m.production_file == client_path)
+            .map(|m| m.test_files.contains(&test_path))
+            .unwrap_or(false);
+        assert!(
+            client_mapped,
+            "test_client.py should be mapped to pkg/client.py via barrel L2. mappings={:?}",
+            result
+        );
+
+        // Then: pkg/aio/client.py is NOT mapped (barrel only re-exports pkg.client)
+        let aio_mapped = result
+            .iter()
+            .find(|m| m.production_file == aio_client_path)
+            .map(|m| m.test_files.contains(&test_path))
+            .unwrap_or(false);
+        assert!(
+            !aio_mapped,
+            "test_client.py should NOT be mapped to pkg/aio/client.py. mappings={:?}",
             result
         );
     }

--- a/docs/cycles/20260323_2049_python-observe-stem-collision-guard.md
+++ b/docs/cycles/20260323_2049_python-observe-stem-collision-guard.md
@@ -1,0 +1,143 @@
+---
+feature: python-observe-stem-collision-guard
+cycle: 20260323_2049
+phase: DONE
+complexity: standard
+test_count: 4
+risk_level: low
+codex_session_id: ""
+created: 2026-03-23 20:49
+updated: 2026-03-23 21:05
+---
+
+# Python observe stem collision guard (#126)
+
+## Scope Definition
+
+### In Scope
+- [ ] `crates/lang-python/src/observe.rs` の stem-only fallback ブロックに `prod_indices.len() == 1` ガードを追加
+- [ ] L874-876 のコメント ("recall takes priority") を precision guard に修正
+
+### Out of Scope
+- L2 import tracing 自体の変更 (理由: 今回はガードのみ。L2 は既存実装に委ねる)
+- 他言語の observe への変更 (理由: Python 固有の問題)
+
+### Files to Change (target: 10 or less)
+- `crates/lang-python/src/observe.rs` (edit)
+- `crates/lang-python/src/observe.rs` (edit) — PY-L1X-04 期待値変更 + PY-L1X-06/07 新規追加 (inline tests)
+
+## Environment
+
+### Scope
+- Layer: Backend
+- Plugin: rust
+- Risk: 20/100 (PASS)
+
+### Runtime
+- Language: Rust (stable)
+
+### Dependencies (key packages)
+- tree-sitter: workspace
+- exspec-core: workspace
+
+### Risk Interview (BLOCK only)
+(該当なし — Risk 20/100 PASS)
+
+## Context & Dependencies
+
+### Reference Documents
+- [ROADMAP.md] - v0.4.2 scope に #126 が明記済み
+- [CONSTITUTION.md] - observe ship criteria: Precision >= 98%, Recall >= 90%
+
+### Dependent Features
+- Python observe L1 core (ディレクトリ+stem ペア): `crates/lang-python/src/observe.rs`
+- Python observe L2 import tracing: `crates/lang-python/src/observe.rs`
+
+### Related Issues/PRs
+- Issue #126: Python observe stem collision guard
+
+## Test List
+
+### TODO
+(none)
+
+### WIP → DONE (RED phase)
+- [x] TC-01: PY-L1X-04 -- stem collision は L1 でマップしない (期待値変更) -- FAIL (expected)
+- [x] TC-02: PY-L1X-06 -- stem collision + L2 import で正しくマップ + strategy==ImportTracing (新規) -- FAIL (expected)
+- [x] TC-03: PY-L1X-07 -- stem collision + barrel import で fan-out 正常動作 (新規) -- FAIL (expected)
+- [x] TC-04: PY-L1X-01 -- 1対1 stem match は変わらない (回帰確認) -- PASS (expected)
+
+### WIP
+(none)
+
+### DISCOVERED
+- [ ] relative direct import (`from ._sub import X`) が `direct_import_indices` に追加されない (assertion filter bypass が relative import に効かない) -- #119 の追加ギャップ
+- [ ] `direct_import_indices.intersection(&all_matched)` は構築上 `direct_import_indices` と等価 -- 可読性改善
+
+### DONE
+- [x] RED phase: 4テスト作成完了。TC-01/02/03 FAIL、TC-04 PASS を確認
+
+## Implementation Notes
+
+### Goal
+Python observe の stem-only fallback で同一 stem を持つ複数の production file が存在する場合、全てにマップする代わりに L2 import tracing に委ねることで precision を向上させる。
+
+### Background
+Python observe の stem-only fallback は、L1 core（ディレクトリ+stem ペア）で未マッチのテストに対し stem のみで cross-directory マッチを行う。現状は複数の production file が同一 stem を持つ場合、全てにマップする（recall 優先）。`models.py`, `utils.py` 等の common name が複数ディレクトリに存在する大規模プロジェクトで precision が低下するリスクがある。
+
+### Design Approach
+`crates/lang-python/src/observe.rs` L901 付近の stem fallback ブロックに `prod_indices.len() > 1` の早期 continue を追加する。
+
+```rust
+// 変更後:
+if let Some(prod_indices) = stem_to_prod_indices.get(tstem) {
+    if prod_indices.len() > 1 {
+        continue; // stem collision: defer to L2 import tracing
+    }
+    for &idx in prod_indices {
+```
+
+stem collision の場合は L2 import tracing に委ねる。L2 でもインポートなしなら未マッチとなる（acceptable — precision 優先）。
+
+## Progress Log
+
+### 2026-03-23 20:49 - INIT
+- Cycle doc created from plan file `/Users/morodomi/.claude/plans/buzzing-launching-wand.md`
+- Scope definition ready
+
+### 2026-03-23 21:05 - RED
+- TC-01: `py_l1x_04_stem_ambiguity_maps_to_all` を `py_l1x_04_stem_collision_defers_to_l2` に変更。アサーションを反転（!client_mapped, !aio_mapped）
+- TC-02: `py_l1x_06_stem_collision_with_l2_import_resolves_correctly` を新規追加。strategy==ImportTracing の検証を含む
+- TC-03: `py_l1x_07_stem_collision_with_barrel_import_resolves_correctly` を新規追加。barrel __init__.py 経由での L2 解決
+- TC-04: `py_l1x_01_stem_only_fallback_cross_directory` (1対1 stem) は変更なし、PASS 確認
+- `cargo test -p exspec-lang-python -- py_l1x` 結果: 4 passed, 3 failed (TC-01/02/03 FAIL, TC-04+既存 PASS)
+
+### 2026-03-23 21:10 - GREEN
+- L901 に `if prod_indices.len() > 1 { continue; }` ガード追加
+- L874-876 コメント更新 (precision guard の意図を明記)
+- 全テスト PASS (1,117 tests)
+
+### 2026-03-23 21:12 - REFACTOR
+- チェックリスト7項目を確認、改善不要
+- cargo fmt の差分を修正 (TC-07 の write 呼び出しチェーン)
+- Verification Gate: PASS (tests 1,117, clippy 0, fmt OK, self-dogfooding BLOCK 0)
+- Phase completed
+
+### 2026-03-23 21:15 - REVIEW
+- Security review: PASS (score 5) -- optional 2件
+- Correctness review: PASS/WARN (score 25) -- important 1件 (relative import gap, スコープ外)
+- Aggregate: PASS (score 15)
+- DISCOVERED: relative direct import の assertion filter bypass 未対応、intersection 可読性改善
+- Phase completed
+
+---
+
+## Next Steps
+
+1. [Done] INIT <- Current
+2. [Done] PLAN
+3. [Next] RED
+4. [ ] GREEN
+5. [ ] REFACTOR
+6. [ ] REVIEW
+7. [ ] COMMIT


### PR DESCRIPTION
## Summary

- stem-only fallback で `prod_indices.len() > 1` のガードを追加。同一 stem を持つ複数 production file がある場合、全マッチではなく L2 import tracing に委ねる
- precision 向上: `models.py`, `utils.py` 等の common name による false positive を防止
- テスト 4件: collision guard 動作確認、L2 direct import 解決、L2 barrel import 解決、1対1回帰確認

## Test plan

- [x] `cargo test` -- 1,117 tests all pass
- [x] `cargo clippy -- -D warnings` -- 0 errors
- [x] `cargo fmt --check` -- no diff
- [x] `cargo run -- --lang rust .` -- BLOCK 0
- [ ] httpx dogfooding: `cargo run -- observe --lang python <httpx>` で P/R 確認 (post-merge)

## Review notes

- Socrates adversarial review: 3 objections addressed (dogfooding verification, strategy assert, barrel fan-out test)
- Codex plan review: BLOCK resolved (added TC-03 barrel test, strategy assert, dogfooding to verification)
- Security review: PASS (score 5)
- Correctness review: PASS/WARN (score 25) -- relative import gap filed as #146

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)