### PR TITLE
feat: add direct_import_indices for relative imports (#146)

### DIFF
--- a/crates/lang-python/src/observe.rs
+++ b/crates/lang-python/src/observe.rs
@@ -981,6 +981,15 @@ impl PythonExtractor {
                                 sym_slice,
                                 &mut idx_to_symbols,
                             );
+                            // Direct (non-barrel) bare relative import → assertion filter bypass
+                            // Note: barrel files are skipped above for L1-matched tests only.
+                            // For non-L1-matched tests, barrel imports may reach here, but
+                            // !is_barrel_file prevents them from being added to direct_import_indices.
+                            if !self.is_barrel_file(&resolved) {
+                                for &idx in all_matched.difference(&before) {
+                                    direct_import_indices.insert(idx);
+                                }
+                            }
                         }
                     }
                     continue;
@@ -1010,6 +1019,13 @@ impl PythonExtractor {
                         &canonical_root,
                     );
                     track_new_matches(&all_matched, &before, &import.symbols, &mut idx_to_symbols);
+                    // Direct (non-barrel) non-bare relative import → assertion filter bypass
+                    let is_direct = !self.is_barrel_file(&resolved);
+                    if is_direct {
+                        for &idx in all_matched.difference(&before) {
+                            direct_import_indices.insert(idx);
+                        }
+                    }
                 }
             }
 
@@ -5623,6 +5639,137 @@ class TestMyModel(unittest.TestCase):
         assert!(
             helpers_mapped,
             "pkg/_internal/_helpers.py should be mapped via nested direct import. mappings={:?}",
+            result
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PY-SUBMOD-05: non-bare relative direct import bypass
+    //
+    // `from ._config import Config` is a non-bare relative direct import.
+    // Even though `Config` does not appear in assertions (only `Client` is
+    // asserted, which comes from the barrel), _config.py SHOULD be mapped
+    // because direct_import_indices bypass the assertion filter.
+    // (Fixed in #146: relative import branches now populate direct_import_indices)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn py_submod_05_non_bare_relative_direct_import_bypass() {
+        use std::collections::HashMap;
+        use tempfile::TempDir;
+
+        // Given: pkg/_config.py (non-barrel production file, has Config)
+        //        pkg/_client.py (non-barrel production file, has Client)
+        //        pkg/__init__.py (barrel: re-exports Client from ._client)
+        //        pkg/test_app.py (stem "app", no L1 match to _config or _client):
+        //          import pkg                    <- barrel import
+        //          from ._config import Config   <- non-bare relative direct import
+        //          def test_something():
+        //              assert pkg.Client()       <- assertion uses Client (from _client),
+        //                                           NOT Config (from _config)
+        //
+        // Key: test file is named "test_app.py" (stem "app") so L1 stem matching
+        //      does NOT match _config.py (stem "config") or _client.py (stem "client").
+        let dir = TempDir::new().unwrap();
+        let pkg = dir.path().join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+
+        std::fs::write(pkg.join("_config.py"), "class Config:\n    pass\n").unwrap();
+        std::fs::write(pkg.join("_client.py"), "class Client:\n    pass\n").unwrap();
+        // __init__.py re-exports Client (NOT Config)
+        std::fs::write(pkg.join("__init__.py"), "from ._client import Client\n").unwrap();
+
+        let test_content = "import pkg\nfrom ._config import Config\n\ndef test_something():\n    assert pkg.Client()\n";
+        std::fs::write(pkg.join("test_app.py"), test_content).unwrap();
+
+        let config_path = pkg.join("_config.py").to_string_lossy().into_owned();
+        let client_path = pkg.join("_client.py").to_string_lossy().into_owned();
+        let test_path = pkg.join("test_app.py").to_string_lossy().into_owned();
+
+        let extractor = PythonExtractor::new();
+        let production_files = vec![config_path.clone(), client_path.clone()];
+        let test_sources: HashMap<String, String> = [(test_path.clone(), test_content.to_string())]
+            .into_iter()
+            .collect();
+
+        // When: map_test_files_with_imports is called
+        let result =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+
+        // Then: _config.py IS mapped (non-bare relative direct import bypasses assertion filter)
+        let config_mapped = result
+            .iter()
+            .find(|m| m.production_file == config_path)
+            .map(|m| m.test_files.contains(&test_path))
+            .unwrap_or(false);
+        assert!(
+            config_mapped,
+            "pkg/_config.py should be mapped via non-bare relative direct import (assertion filter bypass). mappings={:?}",
+            result
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PY-SUBMOD-06: bare relative direct import bypass
+    //
+    // `from . import utils` is a bare relative direct import.
+    // Even though `utils` does not appear in assertions (only `Client` is
+    // asserted, which comes from the barrel), utils.py SHOULD be mapped
+    // because direct_import_indices bypass the assertion filter.
+    // (Fixed in #146: relative import branches now populate direct_import_indices)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn py_submod_06_bare_relative_direct_import_bypass() {
+        use std::collections::HashMap;
+        use tempfile::TempDir;
+
+        // Given: pkg/utils.py (non-barrel production file, has helper)
+        //        pkg/_client.py (non-barrel production file, has Client)
+        //        pkg/__init__.py (barrel: re-exports Client from ._client)
+        //        pkg/test_app.py (stem "app", no L1 match to utils or _client):
+        //          import pkg              <- barrel import
+        //          from . import utils     <- bare relative direct import
+        //          def test_something():
+        //              assert pkg.Client() <- assertion uses Client (from _client),
+        //                                    NOT utils.helper
+        //
+        // Key: test file is named "test_app.py" (stem "app") so L1 stem matching
+        //      does NOT match utils.py (stem "utils") or _client.py (stem "client").
+        let dir = TempDir::new().unwrap();
+        let pkg = dir.path().join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+
+        std::fs::write(pkg.join("utils.py"), "def helper(): return True\n").unwrap();
+        std::fs::write(pkg.join("_client.py"), "class Client:\n    pass\n").unwrap();
+        // __init__.py re-exports Client (NOT utils)
+        std::fs::write(pkg.join("__init__.py"), "from ._client import Client\n").unwrap();
+
+        let test_content =
+            "import pkg\nfrom . import utils\n\ndef test_something():\n    assert pkg.Client()\n";
+        std::fs::write(pkg.join("test_app.py"), test_content).unwrap();
+
+        let utils_path = pkg.join("utils.py").to_string_lossy().into_owned();
+        let client_path = pkg.join("_client.py").to_string_lossy().into_owned();
+        let test_path = pkg.join("test_app.py").to_string_lossy().into_owned();
+
+        let extractor = PythonExtractor::new();
+        let production_files = vec![utils_path.clone(), client_path.clone()];
+        let test_sources: HashMap<String, String> = [(test_path.clone(), test_content.to_string())]
+            .into_iter()
+            .collect();
+
+        // When: map_test_files_with_imports is called
+        let result =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+
+        // Then: utils.py IS mapped (bare relative direct import bypasses assertion filter)
+        let utils_mapped = result
+            .iter()
+            .find(|m| m.production_file == utils_path)
+            .map(|m| m.test_files.contains(&test_path))
+            .unwrap_or(false);
+        assert!(
+            utils_mapped,
+            "pkg/utils.py should be mapped via bare relative direct import (assertion filter bypass). mappings={:?}",
             result
         );
     }

--- a/docs/cycles/20260323_2248_python-observe-relative-direct-import.md
+++ b/docs/cycles/20260323_2248_python-observe-relative-direct-import.md
@@ -1,0 +1,177 @@
+---
+feature: python-observe-relative-direct-import
+cycle: 20260323_2248
+phase: RED
+complexity: standard
+test_count: 3
+risk_level: low
+codex_session_id: ""
+created: 2026-03-23 22:48
+updated: 2026-03-23 22:48
+---
+
+# Issue #146: relative direct import の direct_import_indices 追加
+
+## Scope Definition
+
+### In Scope
+- [ ] non-bare relative ブランチ (L991-1013) で non-barrel resolved file を `direct_import_indices` に記録
+- [ ] bare relative ブランチ (L951-986) で non-barrel resolved file を `direct_import_indices` に記録
+
+### Out of Scope
+- absolute direct import ロジックの変更 (#119/#145 で実装済み)
+- L1 マッチング・barrel suppression ロジックの変更
+- 他言語 (TypeScript / PHP / Rust) の observe への波及
+
+### Files to Change (target: 10 or less)
+- `crates/lang-python/src/observe.rs` (edit)
+
+## Environment
+
+### Scope
+- Layer: Backend
+- Plugin: rust (cargo test)
+- Risk: 15 (PASS)
+
+### Runtime
+- Language: Rust
+
+### Dependencies (key packages)
+- tree-sitter: workspace
+- exspec-core: workspace (observe trait, collect_import_matches)
+
+### Risk Interview (BLOCK only)
+(not applicable — PASS)
+
+## Context & Dependencies
+
+### Reference Documents
+- CONSTITUTION.md - static AST analysis only。assertion filter bypass は static 解析の範囲内
+- ROADMAP.md v0.4.2 - #119 の追加ギャップとして v0.4.2 スコープ内
+- Issue #145 (#119 PR) - absolute direct import bypass の実装 (横展開元)
+
+### Dependent Features
+- absolute direct import bypass (#119/#145): 既存実装。同パターンを relative ブランチに横展開
+- assertion filter (PY-AF-06a/06b/09): T3 回帰確認で動作保護
+
+### Related Issues/PRs
+- Issue #146: relative direct import の direct_import_indices 追加
+- PR #145: bypass assertion filter for direct sub-module imports (upstream reference)
+
+## Test List
+
+### TODO
+- [x] TC-01 (PY-SUBMOD-05): non-bare relative direct import bypass
+  - Given: `pkg/_config.py` (non-barrel), `pkg/_client.py`, `pkg/__init__.py` (barrel: re-exports Client), `pkg/test_app.py` に `import pkg` + `from ._config import Config` 相対 import、assertion は `pkg.Client()` (Config 未使用)
+  - When: `map_test_files_with_imports` を実行
+  - Then: `test_app.py` は `pkg/_config.py` にマップされる (direct_import_indices 経由で assertion filter bypass)
+  - Status: RED confirmed (FAIL — relative non-bare branch に direct_import_indices ロジック未追加)
+- [x] TC-02 (PY-SUBMOD-06): bare relative direct import bypass
+  - Given: `pkg/utils.py` (non-barrel), `pkg/_client.py`, `pkg/__init__.py` (barrel: re-exports Client), `pkg/test_app.py` に `import pkg` + `from . import utils` bare relative import、assertion は `pkg.Client()` (utils 未使用)
+  - When: `map_test_files_with_imports` を実行
+  - Then: `test_app.py` は `pkg/utils.py` にマップされる (direct_import_indices 経由で assertion filter bypass)
+  - Status: RED confirmed (FAIL — relative bare branch に direct_import_indices ロジック未追加)
+- [x] TC-03 (PY-SUBMOD-01-04 回帰): 既存 absolute direct import テストが引き続き PASS すること
+  - Status: PASS (241 passed, 2 failed)
+
+### WIP
+(none)
+
+### DONE
+- TC-01, TC-02, TC-03 テスト作成完了 (RED phase)
+
+### DISCOVERED
+(none)
+
+### DONE
+(none)
+
+## Implementation Notes
+
+### Goal
+
+#119/#145 で実装した absolute direct import bypass を relative import ブランチ (`from ._sub import X`, `from . import sub`) にも適用し、relative direct import でも assertion filter を bypass できるようにする。
+
+### Background
+
+#119/#145 で L2 absolute ループに `direct_import_indices` を追加したが、relative import の2ブランチ (non-bare / bare) には同ロジックが未適用のまま。correctness reviewer (#145 REVIEW phase) が asymmetry を指摘し、Issue #146 として filed された。
+
+#### Root Cause
+
+```
+tests/test_app.py:
+  import pkg              → barrel → _config.py, etc.
+  from ._config import Config  → relative direct → _config.py
+
+assertions: assert pkg.something()
+  → asserted_imports = {"something", "pkg", ...}
+  → _config.py idx_to_symbols = {"Config"} → NOT in asserted_imports
+  → asserted_matched non-empty (barrel indices pass)
+  → _config.py excluded (relative branch に bypass ロジックなし)
+```
+
+### Design Approach
+
+**relative direct import (non-barrel) も absolute と同様に assertion filter を bypass する。**
+
+根拠: `from ._submodule import X` / `from . import sub` は「そのモジュールをテストする意図」の強いシグナル。absolute 同様、明示的に特定の production file を指定している。
+
+#### 実装
+
+修正箇所: `crates/lang-python/src/observe.rs`
+
+**変更1: non-bare relative ブランチ (L991-1013)**
+
+```rust
+// L1003 の before 定義は既存
+let before = all_matched.clone();
+// ... collect_import_matches + track_new_matches (既存) ...
+
+// 追加: direct (non-barrel) relative import → assertion filter bypass
+let is_direct = !self.is_barrel_file(&resolved);
+if is_direct {
+    for &idx in all_matched.difference(&before) {
+        direct_import_indices.insert(idx);
+    }
+}
+```
+
+**変更2: bare relative ブランチ (L951-986)**
+
+```rust
+// L969 の before 定義は既存
+let before = all_matched.clone();
+// ... collect_import_matches + track_new_matches (既存) ...
+
+// 追加: direct (non-barrel) bare relative import → assertion filter bypass
+if !self.is_barrel_file(&resolved) {
+    for &idx in all_matched.difference(&before) {
+        direct_import_indices.insert(idx);
+    }
+}
+```
+
+注意: bare relative は barrel suppression で既に `is_barrel_file` チェック済み (L963)。barrel の場合は L966 で `continue` されるため、ここに到達する resolved は必ず non-barrel。`if !self.is_barrel_file(&resolved)` は常に true だが、absolute ブランチとの一貫性のために明示的に書く。
+
+#### Verification
+
+```bash
+cargo test -p exspec-lang-python -- py_submod   # SUBMOD テスト全体
+cargo test                                       # 全テスト
+cargo clippy -- -D warnings                     # 静的解析
+cargo fmt --check                               # フォーマット
+cargo run -- --lang rust .                      # self-dogfooding
+```
+
+## Progress Log
+
+### 2026-03-23 22:48 - INIT
+- Cycle doc created from plan file buzzing-launching-wand.md
+- Design Review Gate: PASS (score 15/100)
+- Scope definition ready
+
+### 2026-03-23 RED - テスト作成完了
+- PY-SUBMOD-05, PY-SUBMOD-06 を `crates/lang-python/src/observe.rs` に追加
+- テストシナリオ: L1 stem match を避けるため `test_app.py` (stem "app") を使用。barrel + relative direct import の組み合わせで asserted_matched が non-empty になるシナリオを構成
+- RED 確認: py_submod_05, py_submod_06 が FAIL (期待通り)
+- 既存テスト: 241 PASS (回帰なし)


### PR DESCRIPTION
## Summary

- relative import ブランチ (bare / non-bare) に `direct_import_indices` ロジックを追加
- #119/#145 で実装した assertion filter bypass が relative import にも適用されるように
- `from ._config import Config` 等の relative direct import が assertion filter で除外されなくなる

## Test plan

- [x] `cargo test` -- 1,119 tests all pass
- [x] `cargo clippy -- -D warnings` -- 0 errors
- [x] `cargo fmt --check` -- no diff
- [x] `cargo run -- --lang rust .` -- BLOCK 0
- [x] PY-SUBMOD-05: non-bare relative direct import bypass
- [x] PY-SUBMOD-06: bare relative direct import bypass
- [x] PY-SUBMOD-01-04: absolute import regression pass

## Review notes

- Security review: PASS (score 3)
- Correctness review: PASS (score 15) -- optional コメント修正を反映済み

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)