### PR TITLE
feat: add same-file helper tracing for TypeScript (#151)

### DIFF
--- a/crates/lang-typescript/queries/helper_trace.scm
+++ b/crates/lang-typescript/queries/helper_trace.scm
@@ -1,0 +1,15 @@
+; Function calls (free function — helper call in test body)
+(call_expression function: (identifier) @call_name)
+
+; Function declarations
+(function_declaration
+  name: (identifier) @def_name
+  body: (statement_block) @def_body)
+
+; Arrow function helpers assigned to const/let/var
+; e.g. const assertValid = (x) => { expect(x)... }
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @def_name
+    value: (arrow_function
+      body: (statement_block) @def_body)))

--- a/crates/lang-typescript/src/lib.rs
+++ b/crates/lang-typescript/src/lib.rs
@@ -5,8 +5,9 @@ use std::sync::OnceLock;
 
 use exspec_core::extractor::{FileAnalysis, LanguageExtractor, TestAnalysis, TestFunction};
 use exspec_core::query_utils::{
-    collect_mock_class_names, count_captures, count_captures_within_context,
-    count_duplicate_literals, extract_suppression_from_previous_line, has_any_match,
+    apply_same_file_helper_tracing, collect_mock_class_names, count_captures,
+    count_captures_within_context, count_duplicate_literals,
+    extract_suppression_from_previous_line, has_any_match,
 };
 use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Parser, Query, QueryCursor};
@@ -23,6 +24,7 @@ const PRIVATE_IN_ASSERTION_QUERY: &str = include_str!("../queries/private_in_ass
 const ERROR_TEST_QUERY: &str = include_str!("../queries/error_test.scm");
 const RELATIONAL_ASSERTION_QUERY: &str = include_str!("../queries/relational_assertion.scm");
 const WAIT_AND_SEE_QUERY: &str = include_str!("../queries/wait_and_see.scm");
+const HELPER_TRACE_QUERY: &str = include_str!("../queries/helper_trace.scm");
 
 fn ts_language() -> tree_sitter::Language {
     tree_sitter_typescript::LANGUAGE_TSX.into()
@@ -44,6 +46,7 @@ static PRIVATE_IN_ASSERTION_QUERY_CACHE: OnceLock<Query> = OnceLock::new();
 static ERROR_TEST_QUERY_CACHE: OnceLock<Query> = OnceLock::new();
 static RELATIONAL_ASSERTION_QUERY_CACHE: OnceLock<Query> = OnceLock::new();
 static WAIT_AND_SEE_QUERY_CACHE: OnceLock<Query> = OnceLock::new();
+static HELPER_TRACE_QUERY_CACHE: OnceLock<Query> = OnceLock::new();
 
 pub struct TypeScriptExtractor;
 
@@ -324,7 +327,7 @@ impl LanguageExtractor for TypeScriptExtractor {
         let has_relational_assertion =
             has_any_match(relational_query, "relational", root, source_bytes);
 
-        FileAnalysis {
+        let mut file_analysis = FileAnalysis {
             file: file_path.to_string(),
             functions,
             has_pbt_import,
@@ -332,7 +335,23 @@ impl LanguageExtractor for TypeScriptExtractor {
             has_error_test,
             has_relational_assertion,
             parameterized_count,
-        }
+        };
+
+        // Apply same-file helper tracing (Phase 23b — TypeScript port)
+        // helper_trace.scm contains both @call_name and @def_name/@def_body captures
+        // in a single query. Same object is passed as both call_query and def_query by design.
+        let helper_trace_query = cached_query(&HELPER_TRACE_QUERY_CACHE, HELPER_TRACE_QUERY);
+        let assertion_query_for_trace = cached_query(&ASSERTION_QUERY_CACHE, ASSERTION_QUERY);
+        apply_same_file_helper_tracing(
+            &mut file_analysis,
+            &tree,
+            source_bytes,
+            helper_trace_query,
+            helper_trace_query,
+            assertion_query_for_trace,
+        );
+
+        file_analysis
     }
 }
 
@@ -1999,6 +2018,155 @@ describe('d', () => {
             funcs[6].analysis.assertion_count, 0,
             "TC-07 no assertion should have assertion_count == 0, got {}",
             funcs[6].analysis.assertion_count
+        );
+    }
+
+    // --- Same-file helper tracing (Phase 23b TypeScript port, TC-01 ~ TC-08) ---
+
+    #[test]
+    fn helper_tracing_tc01_calls_helper_with_assert() {
+        // TC-01: test that calls a helper with assertion → assertion_count >= 1 after tracing
+        let source = fixture("t001_pass_helper_tracing.test.ts");
+        let extractor = TypeScriptExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.test.ts");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "TC-01 calls helper with assert")
+            .expect("TC-01 calls helper with assert not found");
+        assert!(
+            func.analysis.assertion_count >= 1,
+            "TC-01: expected assertion_count >= 1, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc02_calls_helper_without_assert() {
+        // TC-02: test that calls a helper WITHOUT assertion → assertion_count stays 0
+        let source = fixture("t001_pass_helper_tracing.test.ts");
+        let extractor = TypeScriptExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.test.ts");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "TC-02 calls helper without assert")
+            .expect("TC-02 calls helper without assert not found");
+        assert_eq!(
+            func.analysis.assertion_count, 0,
+            "TC-02: expected assertion_count == 0, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc03_has_own_assert_plus_helper() {
+        // TC-03: test with own assert + calls helper → assertion_count >= 1 (direct assertion)
+        let source = fixture("t001_pass_helper_tracing.test.ts");
+        let extractor = TypeScriptExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.test.ts");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "TC-03 has own assert plus helper")
+            .expect("TC-03 has own assert plus helper not found");
+        assert!(
+            func.analysis.assertion_count >= 1,
+            "TC-03: expected assertion_count >= 1, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc04_calls_undefined_function() {
+        // TC-04: calling a function not defined in the file → no crash, assertion_count stays 0
+        let source = fixture("t001_pass_helper_tracing.test.ts");
+        let extractor = TypeScriptExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.test.ts");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "TC-04 calls undefined function")
+            .expect("TC-04 calls undefined function not found");
+        assert_eq!(
+            func.analysis.assertion_count, 0,
+            "TC-04: expected assertion_count == 0, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc05_two_hop_tracing() {
+        // TC-05: 2-hop helper (intermediate → checkResult) — only 1-hop traced.
+        // intermediate() itself has NO assertion → assertion_count stays 0
+        let source = fixture("t001_pass_helper_tracing.test.ts");
+        let extractor = TypeScriptExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.test.ts");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "TC-05 two hop tracing")
+            .expect("TC-05 two hop tracing not found");
+        assert_eq!(
+            func.analysis.assertion_count, 0,
+            "TC-05: 2-hop not traced, expected assertion_count == 0, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc06_with_assertion_early_return() {
+        // TC-06: test with own assertion → helper tracing early returns, assertion_count unchanged
+        let source = fixture("t001_pass_helper_tracing.test.ts");
+        let extractor = TypeScriptExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.test.ts");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "TC-06 with assertion early return")
+            .expect("TC-06 with assertion early return not found");
+        assert!(
+            func.analysis.assertion_count >= 1,
+            "TC-06: expected assertion_count >= 1, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc07_multiple_calls_same_helper() {
+        // TC-07: test that calls same helper multiple times
+        // Should deduplicate and count helper assertions once, not once per call.
+        // checkResult has exactly 1 assert → dedup → assertion_count == 1
+        let source = fixture("t001_pass_helper_tracing.test.ts");
+        let extractor = TypeScriptExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.test.ts");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "TC-07 multiple calls same helper")
+            .expect("TC-07 multiple calls same helper not found");
+        assert_eq!(
+            func.analysis.assertion_count, 1,
+            "TC-07: dedup expected assertion_count == 1, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc08_arrow_function_helper() {
+        // TC-08: arrow function helper with assertion → assertion_count >= 1
+        let source = fixture("t001_pass_helper_tracing.test.ts");
+        let extractor = TypeScriptExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.test.ts");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "TC-08 arrow function helper")
+            .expect("TC-08 arrow function helper not found");
+        assert!(
+            func.analysis.assertion_count >= 1,
+            "TC-08: arrow function helper expected assertion_count >= 1, got {}",
+            func.analysis.assertion_count
         );
     }
 }

--- a/docs/cycles/20260324_0042_typescript-same-file-helper-tracing.md
+++ b/docs/cycles/20260324_0042_typescript-same-file-helper-tracing.md
@@ -1,0 +1,152 @@
+---
+feature: typescript-same-file-helper-tracing
+cycle: 20260324_0042
+phase: DONE
+complexity: standard
+test_count: 8
+risk_level: low
+codex_session_id: ""
+created: 2026-03-24 00:42
+updated: 2026-03-24 01:00
+---
+
+# #151 Same-file helper tracing for TypeScript (Phase 23b port)
+
+## Scope Definition
+
+### In Scope
+- [ ] `crates/lang-typescript/queries/helper_trace.scm` 新規作成
+- [ ] `crates/lang-typescript/src/lib.rs` に OnceLock cache + `apply_same_file_helper_tracing()` 呼び出し追加
+- [ ] `tests/fixtures/typescript/t001_pass_helper_tracing.test.ts` 新規作成 (TC-01 ~ TC-08)
+- [ ] 統合テスト追加 (lang-typescript lib.rs の #[cfg(test)] 内)
+
+### Out of Scope
+- `this.helper()` メソッド呼び出しトレース (Reason: `member_expression` は `(identifier)` にマッチしない。Python と同じスコープ制限。#153 で対応)
+- arrow function の expression body (`() => expr`) (Reason: `statement_block` にマッチしない。helper としては稀、許容)
+- 2-hop 以上のトレース (Reason: 1-hop only の設計制約)
+
+### Files to Change (target: 10 or less)
+- `crates/lang-typescript/queries/helper_trace.scm` (new)
+- `crates/lang-typescript/src/lib.rs` (edit)
+- `tests/fixtures/typescript/t001_pass_helper_tracing.test.ts` (new)
+
+## Environment
+
+### Scope
+- Layer: Backend (Rust CLI tool)
+- Plugin: rust
+- Risk: 10 (PASS)
+
+### Runtime
+- Language: Rust (cargo)
+
+### Dependencies (key packages)
+- tree-sitter: workspace
+- exspec-core: workspace (apply_same_file_helper_tracing)
+
+### Risk Interview (BLOCK only)
+N/A — LOW risk, no blocking issues.
+
+## Context & Dependencies
+
+### Reference Documents
+- `crates/core/src/query_utils.rs` — `apply_same_file_helper_tracing()` 実装 (そのまま使用)
+- `crates/lang-python/queries/helper_trace.scm` — Python版テンプレート
+- `crates/lang-python/src/lib.rs` — 統合パターンのテンプレート
+- `tests/fixtures/python/t001_pass_helper_tracing.py` — TC設計のテンプレート
+- `ROADMAP.md` v0.4.3: #151 Same-file helper tracing: TypeScript
+
+### Dependent Features
+- Phase 23a (Rust): `crates/core/src/query_utils.rs` — `apply_same_file_helper_tracing()` 提供元
+- #150 (Python): 同一パターンの確立済み実装
+
+### Related Issues/PRs
+- Issue #151: Same-file helper tracing: TypeScript
+- #150 (Python port): 確立済み
+- #153 (メソッド呼び出し): 将来対応
+
+## Test List
+
+### TODO
+(none)
+
+### WIP
+(none)
+
+### DONE (RED)
+- [x] TC-01: helper with expect → test calls helper → assertion_count >= 1 — FAIL (RED confirmed)
+- [x] TC-02: helper without assertion → test calls helper → assertion_count == 0 — PASS (trivial)
+- [x] TC-03: test has own expect + calls helper → assertion_count >= 1 (no extra tracing) — PASS (trivial)
+- [x] TC-04: test calls undefined function → assertion_count == 0 (no crash) — PASS (trivial)
+- [x] TC-05: 2-hop: test → intermediate → checkResult → assertion_count == 0 (1-hop only) — PASS (trivial)
+- [x] TC-06: test with own assertion → early return → assertion_count unchanged — PASS (trivial)
+- [x] TC-07: multiple calls to same helper → dedup → assertion_count == 1 — FAIL (RED confirmed)
+- [x] TC-08: arrow function helper with expect → assertion_count >= 1 — FAIL (RED confirmed)
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+(none)
+
+## Implementation Notes
+
+### Goal
+Phase 23a (Rust) → #150 (Python) と同じ same-file helper tracing を TypeScript にポートする。nestjs dogfooding で 13 BLOCK のうち 8 が helper delegation によるもので、これを解消する。
+
+### Background
+`core` の `apply_same_file_helper_tracing()` は言語非依存。Python ポートで確立したパターンをそのまま TypeScript に適用する。TypeScript では `function_declaration` + arrow function in `variable_declarator` の2パターンが必要。
+
+### Design Approach
+
+#### `helper_trace.scm` (新規)
+```scm
+; Function calls (free function — helper call in test body)
+(call_expression function: (identifier) @call_name)
+
+; Function declarations
+(function_declaration
+  name: (identifier) @def_name
+  body: (statement_block) @def_body)
+
+; Arrow function helpers assigned to const/let/var
+; e.g. const assertValid = (x) => { expect(x)... }
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @def_name
+    value: (arrow_function
+      body: (statement_block) @def_body)))
+```
+
+#### `lib.rs` 変更 (3点)
+1. import: `use exspec_core::query_utils::apply_same_file_helper_tracing;`
+2. 定数 + OnceLock: `HELPER_TRACE_QUERY` / `HELPER_TRACE_QUERY_CACHE`
+3. `extract_file_analysis()` にて FileAnalysis 構築後・return 前に `apply_same_file_helper_tracing()` 呼び出し
+
+## Progress Log
+
+### 2026-03-24 00:42 - INIT
+- Cycle doc created
+- Scope definition ready
+
+### 2026-03-24 01:00 - RED
+- Fixture created: tests/fixtures/typescript/t001_pass_helper_tracing.test.ts (TC-01 ~ TC-08)
+- Integration tests added: crates/lang-typescript/src/lib.rs (8 tests)
+- RED state verified: TC-01, TC-07, TC-08 FAIL (assertion_count 0, helper tracing not yet implemented)
+- TC-02~06 pass trivially (no tracing needed for zero/own-assertion cases)
+- Self-dogfooding: BLOCK 0
+
+---
+
+## Next Steps
+
+1. [Done] INIT
+2. [Done] PLAN (plan approved)
+3. [Done] RED
+4. [Next] GREEN
+5. [ ] REFACTOR
+6. [ ] REVIEW
+7. [ ] COMMIT

--- a/tests/fixtures/typescript/t001_pass_helper_tracing.test.ts
+++ b/tests/fixtures/typescript/t001_pass_helper_tracing.test.ts
@@ -1,0 +1,62 @@
+// Helper WITH assertion (exactly 1 expect)
+function checkResult(value: number) {
+  expect(value).toBeGreaterThan(0);
+}
+
+// Helper WITHOUT assertion
+function noAssertHelper(value: number) {
+  console.log(value);
+}
+
+// Calls checkResult (2-hop chain) but has NO assertion itself
+function intermediate(value: number) {
+  checkResult(value);
+}
+
+// Arrow function helper with assertion
+const assertPositive = (value: number) => {
+  expect(value).toBeGreaterThan(0);
+};
+
+// TC-01: calls helper with assertion → assertion_count >= 1
+it('TC-01 calls helper with assert', () => {
+  checkResult(42);
+});
+
+// TC-02: calls helper without assertion → assertion_count == 0
+it('TC-02 calls helper without assert', () => {
+  noAssertHelper(42);
+});
+
+// TC-03: has own expect + calls helper → assertion_count >= 1 (no extra tracing)
+it('TC-03 has own assert plus helper', () => {
+  expect(1).toBe(1);
+  checkResult(42);
+});
+
+// TC-04: calls undefined function → no crash, assertion_count == 0
+it('TC-04 calls undefined function', () => {
+  undefinedFunction(42);
+});
+
+// TC-05: 2-hop: test → intermediate → checkResult — only 1-hop traced.
+// intermediate() itself has NO assertion → assertion_count stays 0
+it('TC-05 two hop tracing', () => {
+  intermediate(42);
+});
+
+// TC-06: test with own assertion → early return path, assertion_count unchanged
+it('TC-06 with assertion early return', () => {
+  expect(true).toBe(true);
+});
+
+// TC-07: calls checkResult() twice → dedup, assertion_count == 1 (not 2)
+it('TC-07 multiple calls same helper', () => {
+  checkResult(1);
+  checkResult(2);
+});
+
+// TC-08: arrow function helper with assertion → assertion_count >= 1
+it('TC-08 arrow function helper', () => {
+  assertPositive(42);
+});


### PR DESCRIPTION
## Summary
- Port same-file helper delegation tracing to TypeScript (Phase 23b)
- Tests delegating assertions to helpers no longer false-positive as T001 BLOCK
- TC-08: arrow function helper support (TS-specific addition)
- Scope: free function calls only (`this.method()` deferred to #153)

## Changes
- `crates/lang-typescript/queries/helper_trace.scm` — new query (call + function_declaration + arrow_function)
- `crates/lang-typescript/src/lib.rs` — OnceLock cache + `apply_same_file_helper_tracing()` integration
- `tests/fixtures/typescript/t001_pass_helper_tracing.test.ts` — 8 test cases (TC-01 to TC-08)

## Test plan
- [x] `cargo test` — 1134 tests pass (233 TS)
- [x] `cargo clippy -- -D warnings` — 0 errors
- [x] `cargo fmt --check` — no diff
- [x] `cargo run -- --lang rust .` — BLOCK 0

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)