### PR TITLE
feat: add same-file helper tracing for PHP (#152)

### DIFF
--- a/crates/lang-php/queries/helper_trace.scm
+++ b/crates/lang-php/queries/helper_trace.scm
@@ -1,0 +1,7 @@
+; Function calls (free function — helper call in test body)
+(function_call_expression function: (name) @call_name)
+
+; Function definitions (helper function with body)
+(function_definition
+  name: (name) @def_name
+  body: (compound_statement) @def_body)

--- a/crates/lang-php/src/lib.rs
+++ b/crates/lang-php/src/lib.rs
@@ -4,8 +4,9 @@ use std::sync::OnceLock;
 
 use exspec_core::extractor::{FileAnalysis, LanguageExtractor, TestAnalysis, TestFunction};
 use exspec_core::query_utils::{
-    collect_mock_class_names, count_captures, count_captures_within_context,
-    count_duplicate_literals, extract_suppression_from_previous_line, has_any_match,
+    apply_same_file_helper_tracing, collect_mock_class_names, count_captures,
+    count_captures_within_context, count_duplicate_literals,
+    extract_suppression_from_previous_line, has_any_match,
 };
 use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Parser, Query, QueryCursor};
@@ -23,6 +24,7 @@ const ERROR_TEST_QUERY: &str = include_str!("../queries/error_test.scm");
 const RELATIONAL_ASSERTION_QUERY: &str = include_str!("../queries/relational_assertion.scm");
 const WAIT_AND_SEE_QUERY: &str = include_str!("../queries/wait_and_see.scm");
 const SKIP_TEST_QUERY: &str = include_str!("../queries/skip_test.scm");
+const HELPER_TRACE_QUERY: &str = include_str!("../queries/helper_trace.scm");
 
 fn php_language() -> tree_sitter::Language {
     tree_sitter_php::LANGUAGE_PHP.into()
@@ -45,6 +47,7 @@ static ERROR_TEST_QUERY_CACHE: OnceLock<Query> = OnceLock::new();
 static RELATIONAL_ASSERTION_QUERY_CACHE: OnceLock<Query> = OnceLock::new();
 static WAIT_AND_SEE_QUERY_CACHE: OnceLock<Query> = OnceLock::new();
 static SKIP_TEST_QUERY_CACHE: OnceLock<Query> = OnceLock::new();
+static HELPER_TRACE_QUERY_CACHE: OnceLock<Query> = OnceLock::new();
 
 pub struct PhpExtractor;
 
@@ -445,7 +448,7 @@ impl LanguageExtractor for PhpExtractor {
         let has_relational_assertion =
             has_any_match(relational_query, "relational", root, source_bytes);
 
-        FileAnalysis {
+        let mut file_analysis = FileAnalysis {
             file: file_path.to_string(),
             functions,
             has_pbt_import,
@@ -453,7 +456,23 @@ impl LanguageExtractor for PhpExtractor {
             has_error_test,
             has_relational_assertion,
             parameterized_count,
-        }
+        };
+
+        // Apply same-file helper tracing (Phase 23b — PHP port)
+        // helper_trace.scm contains both @call_name and @def_name/@def_body captures
+        // in a single query. Same object is passed as both call_query and def_query by design.
+        let helper_trace_query = cached_query(&HELPER_TRACE_QUERY_CACHE, HELPER_TRACE_QUERY);
+        let assertion_query_for_trace = cached_query(&ASSERTION_QUERY_CACHE, ASSERTION_QUERY);
+        apply_same_file_helper_tracing(
+            &mut file_analysis,
+            &tree,
+            source_bytes,
+            helper_trace_query,
+            helper_trace_query,
+            assertion_query_for_trace,
+        );
+
+        file_analysis
     }
 }
 
@@ -1945,6 +1964,137 @@ mod tests {
             f.analysis.assertion_count >= 1,
             "addToAssertionCount() should count as assertion, got {}",
             f.analysis.assertion_count
+        );
+    }
+
+    // --- Same-file helper tracing (Phase 23b PHP port, TC-01 ~ TC-07) ---
+
+    #[test]
+    fn helper_tracing_tc01_calls_helper_with_assert() {
+        // TC-01: test that calls a helper with assertion → assertion_count >= 1 after tracing
+        let source = fixture("t001_pass_helper_tracing.php");
+        let extractor = PhpExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.php");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "test_calls_helper_with_assert")
+            .expect("test_calls_helper_with_assert not found");
+        assert!(
+            func.analysis.assertion_count >= 1,
+            "TC-01: helper with assertion traced → assertion_count >= 1, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc02_calls_helper_without_assert() {
+        // TC-02: test that calls a helper WITHOUT assertion → assertion_count stays 0
+        let source = fixture("t001_pass_helper_tracing.php");
+        let extractor = PhpExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.php");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "test_calls_helper_without_assert")
+            .expect("test_calls_helper_without_assert not found");
+        assert_eq!(
+            func.analysis.assertion_count, 0,
+            "TC-02: helper without assertion → assertion_count == 0, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc03_has_own_assert_plus_helper() {
+        // TC-03: test with own assert + calls helper → assertion_count >= 1 (direct assertion)
+        let source = fixture("t001_pass_helper_tracing.php");
+        let extractor = PhpExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.php");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "test_has_own_assert_plus_helper")
+            .expect("test_has_own_assert_plus_helper not found");
+        assert!(
+            func.analysis.assertion_count >= 1,
+            "TC-03: own assertion present → assertion_count >= 1, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc04_calls_undefined_function() {
+        // TC-04: calling a function not defined in the file → no crash, assertion_count stays 0
+        let source = fixture("t001_pass_helper_tracing.php");
+        let extractor = PhpExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.php");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "test_calls_undefined_function")
+            .expect("test_calls_undefined_function not found");
+        assert_eq!(
+            func.analysis.assertion_count, 0,
+            "TC-04: undefined function call → no crash, assertion_count == 0, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc05_two_hop_tracing() {
+        // TC-05: 2-hop helper (intermediate → check_result) — only 1-hop traced.
+        // intermediate() itself has NO assertion → assertion_count stays 0
+        let source = fixture("t001_pass_helper_tracing.php");
+        let extractor = PhpExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.php");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "test_two_hop_tracing")
+            .expect("test_two_hop_tracing not found");
+        assert_eq!(
+            func.analysis.assertion_count, 0,
+            "TC-05: 2-hop helper not traced → assertion_count == 0, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc06_with_assertion_early_return() {
+        // TC-06: test with own assertion → helper tracing early returns, assertion_count unchanged
+        let source = fixture("t001_pass_helper_tracing.php");
+        let extractor = PhpExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.php");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "test_with_assertion_early_return")
+            .expect("test_with_assertion_early_return not found");
+        assert!(
+            func.analysis.assertion_count >= 1,
+            "TC-06: own assertion present → assertion_count >= 1, got {}",
+            func.analysis.assertion_count
+        );
+    }
+
+    #[test]
+    fn helper_tracing_tc07_multiple_calls_same_helper() {
+        // TC-07: test that calls same helper multiple times
+        // Should deduplicate and count helper assertions once, not once per call.
+        // check_result has exactly 1 assert → dedup → assertion_count == 1
+        let source = fixture("t001_pass_helper_tracing.php");
+        let extractor = PhpExtractor::new();
+        let fa = extractor.extract_file_analysis(&source, "t001_pass_helper_tracing.php");
+        let func = fa
+            .functions
+            .iter()
+            .find(|f| f.name == "test_multiple_calls_same_helper")
+            .expect("test_multiple_calls_same_helper not found");
+        assert_eq!(
+            func.analysis.assertion_count, 1,
+            "TC-07: multiple calls to same helper → deduplicated, assertion_count == 1, got {}",
+            func.analysis.assertion_count
         );
     }
 }

--- a/docs/cycles/20260324_0816_php-same-file-helper-tracing.md
+++ b/docs/cycles/20260324_0816_php-same-file-helper-tracing.md
@@ -1,0 +1,151 @@
+---
+feature: php-same-file-helper-tracing
+cycle: 20260324_0816
+phase: DONE
+complexity: trivial
+test_count: 7
+risk_level: low
+codex_session_id: ""
+created: 2026-03-24 08:16
+updated: 2026-03-24 RED-complete
+---
+
+# #152 Same-file helper tracing for PHP (Phase 23b port)
+
+## Scope Definition
+
+### In Scope
+- [ ] `crates/lang-php/queries/helper_trace.scm` 新規作成
+- [ ] `crates/lang-php/src/lib.rs` に OnceLock cache + `apply_same_file_helper_tracing()` 呼び出し追加
+- [ ] `tests/fixtures/php/t001_pass_helper_tracing.php` 新規作成 (TC-01 ~ TC-07)
+- [ ] 統合テスト追加 (lang-php lib.rs の #[cfg(test)] 内)
+
+### Out of Scope
+- `$this->helper()` メソッド呼び出しトレース (Reason: `member_call_expression` は `(name)` にマッチしない。same-file では free function のみ対象。#153 で対応)
+- 2-hop 以上のトレース (Reason: 1-hop only の設計制約)
+- laravel/symfony の BLOCK FP 大幅削減 (Reason: 大半が `$this->` パターンのため same-file の直接削減効果は限定的。cross-file #153 のベースライン確立が主目的)
+
+### Files to Change (target: 10 or less)
+- `crates/lang-php/queries/helper_trace.scm` (new)
+- `crates/lang-php/src/lib.rs` (edit)
+- `tests/fixtures/php/t001_pass_helper_tracing.php` (new)
+
+## Environment
+
+### Scope
+- Layer: Backend (Rust CLI tool)
+- Plugin: rust
+- Risk: 10 (PASS)
+
+### Runtime
+- Language: Rust (cargo)
+
+### Dependencies (key packages)
+- tree-sitter: workspace
+- exspec-core: workspace (apply_same_file_helper_tracing)
+
+### Risk Interview (BLOCK only)
+N/A — LOW risk, no blocking issues.
+
+## Context & Dependencies
+
+### Reference Documents
+- `crates/core/src/query_utils.rs` — `apply_same_file_helper_tracing()` 実装 (そのまま使用)
+- `crates/lang-python/queries/helper_trace.scm` — テンプレート
+- `crates/lang-python/src/lib.rs` — 統合パターンのテンプレート
+- `crates/lang-typescript/queries/helper_trace.scm` — TypeScript版 (#151)
+- `crates/lang-typescript/src/lib.rs` — TypeScript統合パターン (#151)
+- `ROADMAP.md` v0.4.3: #152 Same-file helper tracing: PHP
+
+### Dependent Features
+- Phase 23a (Rust): `crates/core/src/query_utils.rs` — `apply_same_file_helper_tracing()` 提供元
+- #150 (Python): 確立済みパターン
+- #151 (TypeScript): 確立済みパターン
+
+### Related Issues/PRs
+- Issue #152: Same-file helper tracing: PHP
+- #150 (Python port): 確立済み
+- #151 (TypeScript port): 確立済み
+- #153 (cross-file / メソッド呼び出し): 将来対応
+
+## Test List
+
+### TODO
+- [ ] TC-01: helper with assertion → test calls helper → assertion_count >= 1
+- [ ] TC-02: helper without assertion → test calls helper → assertion_count == 0
+- [ ] TC-03: test has own assertion + calls helper → assertion_count >= 1 (no extra tracing)
+- [ ] TC-04: test calls undefined function → assertion_count == 0 (no crash)
+- [ ] TC-05: 2-hop: test → intermediate → check_result → assertion_count == 0 (1-hop only)
+- [ ] TC-06: test with own assertion → early return → assertion_count unchanged
+- [ ] TC-07: multiple calls to same helper → dedup → assertion_count == 1
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+(none)
+
+## Implementation Notes
+
+### Goal
+Phase 23a (Rust) → #150 (Python) → #151 (TypeScript) と同じ same-file helper tracing を PHP にポートする。Phase 23b の最後の言語ポート。cross-file (#153) の Go/No-Go 判定用ベースライン確立が主目的。
+
+### Background
+`core` の `apply_same_file_helper_tracing()` は言語非依存。Python/TypeScript ポートで確立したパターンを PHP に適用する。PHP は helper delegation が最大の BLOCK FP 源 (laravel 222, symfony 616) だが、大半が `$this->method()` (cross-file) のため same-file での削減幅は限定的。
+
+PHP 固有ノード名: `function_call_expression` + `(name)` (Python の `identifier` / TS の `identifier` とは異なる)。body は `compound_statement` (Python の `block` / TS の `statement_block` に相当)。
+
+### Design Approach
+
+#### `helper_trace.scm` (新規)
+```scm
+; Function calls (free function — helper call in test body)
+(function_call_expression function: (name) @call_name)
+
+; Function definitions (helper function with body)
+(function_definition
+  name: (name) @def_name
+  body: (compound_statement) @def_body)
+```
+
+#### `lib.rs` 変更 (3点)
+1. import: `use exspec_core::query_utils::apply_same_file_helper_tracing;`
+2. 定数 + OnceLock: `HELPER_TRACE_QUERY` / `HELPER_TRACE_QUERY_CACHE`
+3. `extract_file_analysis()` にて FileAnalysis 構築後・return 前に `apply_same_file_helper_tracing()` 呼び出し
+
+Note: helper_trace.scm は `@call_name` と `@def_name/@def_body` を単一クエリで持つ。同一オブジェクトを call_query / def_query 両方に渡す設計 (Python/TS と同じパターン)。
+
+#### Fixture スタイル
+PHP テストは通常クラスメソッドだが、helper tracing は free function のみ対象。fixture は `function test_*()` スタイル (Pest スタイル) で作成。
+
+## Progress Log
+
+### 2026-03-24 08:16 - INIT
+- Cycle doc created
+- Scope definition ready
+
+### 2026-03-24 RED - COMPLETE
+- Created `tests/fixtures/php/t001_pass_helper_tracing.php` (TC-01 ~ TC-07, free function style)
+- Added 7 integration tests in `crates/lang-php/src/lib.rs` (`helper_tracing_tc01` ~ `tc07`)
+- All 7 tests FAIL as expected (RED state verified)
+- Failure cause: `test_function.scm` does not match free-function `function test_*()` style;
+  functions are absent from `extract_file_analysis` result. GREENフェーズで解決:
+  (1) test_function.scm に free-function パターン追加
+  (2) `crates/lang-php/queries/helper_trace.scm` 新規作成
+  (3) `lib.rs` に `apply_same_file_helper_tracing()` 呼び出し追加
+- self-dogfooding: BLOCK 0 (unchanged)
+
+---
+
+## Next Steps
+
+1. [Done] INIT <- Current
+2. [Done] PLAN (plan approved)
+3. [Next] RED
+4. [ ] GREEN
+5. [ ] REFACTOR
+6. [ ] REVIEW
+7. [ ] COMMIT

--- a/tests/fixtures/php/t001_pass_helper_tracing.php
+++ b/tests/fixtures/php/t001_pass_helper_tracing.php
@@ -1,0 +1,50 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+// Helper WITH assertion (exactly 1 assert — free function at file level)
+function check_result($value) {
+    \PHPUnit\Framework\Assert::assertTrue($value > 0);
+}
+
+// Helper WITHOUT assertion
+function no_assert_helper($value) {
+    echo $value;
+}
+
+// 2-hop chain
+function intermediate($value) {
+    check_result($value);
+}
+
+class HelperTracingTest extends TestCase {
+    // TC-01
+    public function test_calls_helper_with_assert() {
+        check_result(42);
+    }
+    // TC-02
+    public function test_calls_helper_without_assert() {
+        no_assert_helper(42);
+    }
+    // TC-03
+    public function test_has_own_assert_plus_helper() {
+        $this->assertTrue(true);
+        check_result(42);
+    }
+    // TC-04
+    public function test_calls_undefined_function() {
+        undefined_function(42);
+    }
+    // TC-05
+    public function test_two_hop_tracing() {
+        intermediate(42);
+    }
+    // TC-06
+    public function test_with_assertion_early_return() {
+        $this->assertTrue(true);
+    }
+    // TC-07
+    public function test_multiple_calls_same_helper() {
+        check_result(1);
+        check_result(2);
+    }
+}


### PR DESCRIPTION
## Summary
- Port same-file helper delegation tracing to PHP (Phase 23b)
- Tests delegating assertions to free-function helpers no longer false-positive as T001 BLOCK
- PHPUnit class-style fixture with file-level helper functions
- Scope: free function calls only (`$this->method()` deferred to #153)

## Changes
- `crates/lang-php/queries/helper_trace.scm` — new query (function_call_expression + function_definition)
- `crates/lang-php/src/lib.rs` — OnceLock cache + `apply_same_file_helper_tracing()` integration
- `tests/fixtures/php/t001_pass_helper_tracing.php` — 7 test cases (TC-01 to TC-07)

## Test plan
- [x] `cargo test` — 1141 tests pass (143 PHP)
- [x] `cargo clippy -- -D warnings` — 0 errors
- [x] `cargo fmt --check` — no diff
- [x] `cargo run -- --lang rust .` — BLOCK 0

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)