### PR TITLE
feat: add --l1-exclusive flag for observe (#131)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,34 +9,22 @@
 
 ## Now
 
-### v0.4.3: lint BLOCK FP reduction + observe precision
+### v0.4.3: observe precision + ship criteria
 
-Goal: Reduce BLOCK FP from helper delegation via same-file tracing (3 language ports), improve observe precision, and begin Rust/PHP observe ship criteria audit.
+Goal: Improve observe precision and graduate Rust/PHP observe from experimental to stable.
 
 | Issue | Task | Type | Impact |
 |-------|------|------|--------|
-| #150 | Same-file helper tracing: Python | lint | **DONE** (PR #155). Dogfooding: 0 BLOCK change |
-| #151 | Same-file helper tracing: TypeScript | lint | **DONE** (PR #156). Dogfooding: nestjs -2 BLOCK |
-| #152 | Same-file helper tracing: PHP | lint | **DONE** (PR #157). Dogfooding: 0 BLOCK change |
-| #153 | Cross-file 1-hop helper delegation | lint | **DEFERRED to v0.4.4** (all languages FP <= 5%) |
-| #144 | Relative direct import assertion filter bypass | observe | Python observe FN fix |
-| #131 | L1 exclusive mode (opt-in: L1 match suppresses L2) | observe precision | httpx L2 FP ~25 elimination |
+| #144 | Relative direct import assertion filter bypass | observe | **CLOSED** (already fixed by #146 in v0.4.2) |
+| #131 | L1 exclusive mode (`--l1-exclusive` flag) | observe precision | **DONE**. L1-matched tests skip L2 |
 | #129 | L2 fan-out filter (high-frequency mapping suppression) | observe precision | Cross-project utility FP reduction |
-| #149 | Rust/PHP observe formal GT audit | observe ship | Ship criteria validation for experimental languages |
+| #149 | Rust/PHP observe formal GT audit | observe ship | Ship criteria (P>=98%, R>=90%) validation |
 
-**Why**: v0.4.2 dogfooding confirmed helper delegation remains the dominant BLOCK FP across all languages. Phase 23a (same-file, Rust-only) proved the approach; 23b extends to all 4 languages (#150/#151/#152 same-file, #153 cross-file). #144 is a v0.4.2 residual observe fix. #131/#129 are low-cost precision improvements. #149 is needed to graduate Rust/PHP observe from "experimental" to "stable".
+**Why**: #150/#151/#152 (same-file helper tracing) は完了したが dogfooding で BLOCK 削減効果はほぼゼロ（helper delegation FP の本体は cross-file class method）。残りは observe 精度改善と ship criteria 確定。
 
-**Execution order**: ~~#150/#151/#152~~ (DONE) → ~~dogfooding~~ (DONE) → ~~#153 Go/No-Go~~ (DEFERRED) → #144/#131/#129 (next) → #149 (last).
+**Execution order**: ~~#144~~ (CLOSED) → #131/#129 (independent) → #149 (GT audit, last).
 
-**Decision: #153 DEFERRED to v0.4.4** -- same-file tracing dogfooding 結果 (2026-03-24): 全言語で BLOCK FP率 <= 5%。same-file helper は実プロジェクトではほぼ使われておらず、helper delegation FP の大半は `self.method()` / `$this->method()` (cross-file class method) パターン。cross-file は v0.4.4 で再評価。dogfooding 数値: requests 10→10, django 32→37, tokio 247→247, clap 43→43, nestjs 13→11, laravel 222→222, symfony 616→617。
-
-**Decision: #93 deferred to backlog** -- v0.4.2 PHP dogfooding showed laravel at 973/1951 mapped (50%) with 100% precision. Multi-segment namespace impact is marginal. Note: PHP observe の50% recall はproduction file coverageであり、test file coverageは89%。production coverage が低いのは「テストのないファイル」が多い構造的要因であり、#93 のmulti-segment解決では改善しない可能性が高い。GT audit (#149) で実際のrecall gapを特定後に再評価。#93 が再スコープに入る条件: GT audit で multi-segment が原因の FN が 10件以上発見された場合。
-
-**Clarification: #144 vs #146** -- #146 (CLOSED) は absolute direct import の `direct_import_indices` 追記。#144 (OPEN) は relative import ブランチでの同等修正。同じ assertion filter bypass 機能の absolute/relative 非対称性を解消する別 Issue。
-
-**Note: Solo-dev constraint and #150/#151/#152 parallel** -- これら3タスクは Phase 23a (Rust) の mechanical port であり、各タスクの実装コストは小さい (helper_trace.scm作成 + OnceLock統合 + fixture)。"large features" ではなく同一アプローチの言語別適用であるため、並列実行は Solo-dev constraint に抵触しない。
-
-**Decision: #149 scope** -- GT audit の結果は ship criteria (P>=98%, R>=90%) に対する判定のみ。PASS なら stable 昇格、FAIL なら追加実装が必要。#93 の再評価はaudit結果の副産物であり、#149 自体のスコープには含めない。
+**Decision: #149 scope** -- GT audit の結果は ship criteria (P>=98%, R>=90%) に対する判定のみ。PASS なら stable 昇格、FAIL なら追加実装が必要。#93 の再評価は audit 結果の副産物。
 
 ## Backlog
 
@@ -52,6 +40,20 @@ Goal: Reduce BLOCK FP from helper delegation via same-file tracing (3 language p
 | P3 | #113/#114/#115 Refactoring (cached_query, dedup, trait) | Internal cleanup |
 
 ## Completed Recently
+
+### Phase 23b: Same-file helper tracing for Python/TypeScript/PHP (2026-03-24)
+
+Goal: Port Phase 23a (Rust) same-file helper tracing to remaining 3 languages.
+
+| Issue | Task | Status |
+|-------|------|--------|
+| #150 | Same-file helper tracing: Python | DONE (PR #155) |
+| #151 | Same-file helper tracing: TypeScript | DONE (PR #156) |
+| #152 | Same-file helper tracing: PHP | DONE (PR #157) |
+
+**Results**: Dogfooding showed near-zero BLOCK reduction. Helper delegation FP is dominated by cross-file class method calls (`self.method()`, `$this->method()`), not free functions. nestjs was the only project with measurable improvement (-2 BLOCK).
+
+**Decision: #153 deferred to v0.4.4** -- All languages BLOCK FP rate <= 5% after same-file tracing. Cross-file helper delegation is the real solution but requires import resolution infrastructure. Re-evaluate when observe precision work is complete.
 
 ### v0.4.2: observe recall/precision improvement + Rust/PHP dogfooding (2026-03-23)
 
@@ -153,12 +155,13 @@ Route extraction (NestJS, FastAPI, Next.js, Django). TS re-dogfood (P=100%, R=91
 - INFO: opinionated, may be intentional
 - Phase 8a results: T101/T102/T108 demoted WARN->INFO, T106 disabled (93% FP)
 
-### Helper delegation (Phase 8a-4, Phase 23a, Phase 23b)
+### Helper delegation (Phase 8a-4, Phase 23a-23b)
 
 - User-owned config + runtime guidance. No framework-specific knowledge in exspec core
-- Phase 23a: same-file helper tracing for Rust (auto-detect assertions in called functions within the same file)
-- Phase 23b: same-file tracing 3言語ポート (v0.4.3 confirmed) + cross-file 1-hop (conditional, Go/No-Go after same-file dogfooding)
-- Dogfooding data: helper delegation is #1 BLOCK FP across all languages (laravel 222, symfony 616, clap 43, requests 10, django 32)
+- Phase 23a: same-file helper tracing for Rust (v0.4.0)
+- Phase 23b: same-file tracing ported to Python/TypeScript/PHP (v0.4.3). Dogfooding result: near-zero BLOCK reduction — helper delegation FP is dominated by cross-file class method calls, not free functions
+- Cross-file 1-hop (#153): deferred to v0.4.4. Requires import resolution or class hierarchy tracing — significantly more complex than same-file
+- `custom_patterns` remains the primary user-facing escape hatch for helper delegation FP
 
 ## Completed Phases
 
@@ -179,5 +182,6 @@ Route extraction (NestJS, FastAPI, Next.js, Django). TS re-dogfood (P=100%, R=91
 | 24 | Python observe: Django tests.py naming convention | v0.4.1 |
 | -- | v0.4.1 cleanup: should_panic exact match, PHP query align, docs, tests | v0.4.1 |
 | -- | observe recall/precision: #85 TS re-export, #119/#126/#146 Python, Rust/PHP dogfood baselines | v0.4.2 |
+| 23b | Same-file helper tracing: Python (#150), TypeScript (#151), PHP (#152). Near-zero BLOCK impact | v0.4.3 |
 
 Detail for completed phases is archived in git history. Key decisions are preserved in "Key Design Decisions" above.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -80,6 +80,10 @@ pub struct ObserveArgs {
     /// Output format (terminal, json)
     #[arg(long, default_value = "terminal")]
     pub format: String,
+
+    /// Suppress L2 import tracing for L1-matched test files
+    #[arg(long)]
+    pub l1_exclusive: bool,
 }
 
 fn is_python_test_file(path: &str) -> bool {
@@ -426,7 +430,7 @@ fn run_observe(args: ObserveArgs) {
                 &args.format,
                 &config,
                 |prod, test_src, root_path| {
-                    ts_ext.map_test_files_with_imports(prod, test_src, root_path)
+                    ts_ext.map_test_files_with_imports(prod, test_src, root_path, args.l1_exclusive)
                 },
                 |prod_files| {
                     let mut all_routes = Vec::new();
@@ -471,7 +475,7 @@ fn run_observe(args: ObserveArgs) {
                 &args.format,
                 &config,
                 |prod, test_src, root_path| {
-                    py_ext.map_test_files_with_imports(prod, test_src, root_path)
+                    py_ext.map_test_files_with_imports(prod, test_src, root_path, args.l1_exclusive)
                 },
                 |production_files| {
                     let mut all_routes = Vec::new();
@@ -506,7 +510,12 @@ fn run_observe(args: ObserveArgs) {
                 &args.format,
                 &config,
                 |prod, test_src, root_path| {
-                    rust_ext.map_test_files_with_imports(prod, test_src, root_path)
+                    rust_ext.map_test_files_with_imports(
+                        prod,
+                        test_src,
+                        root_path,
+                        args.l1_exclusive,
+                    )
                 },
                 |_| Vec::new(),
             );
@@ -520,7 +529,12 @@ fn run_observe(args: ObserveArgs) {
                 &args.format,
                 &config,
                 |prod, test_src, root_path| {
-                    php_ext.map_test_files_with_imports(prod, test_src, root_path)
+                    php_ext.map_test_files_with_imports(
+                        prod,
+                        test_src,
+                        root_path,
+                        args.l1_exclusive,
+                    )
                 },
                 |_| Vec::new(),
             );

--- a/crates/lang-php/src/observe.rs
+++ b/crates/lang-php/src/observe.rs
@@ -421,6 +421,7 @@ impl PhpExtractor {
         production_files: &[String],
         test_sources: &HashMap<String, String>,
         scan_root: &Path,
+        l1_exclusive: bool,
     ) -> Vec<FileMapping> {
         let test_file_list: Vec<String> = test_sources.keys().cloned().collect();
 
@@ -446,9 +447,18 @@ impl PhpExtractor {
             .map(|m| m.test_files.iter().cloned().collect())
             .collect();
 
+        // Collect set of test files matched by L1 for l1_exclusive mode
+        let layer1_matched: std::collections::HashSet<String> = layer1_tests_per_prod
+            .iter()
+            .flat_map(|s| s.iter().cloned())
+            .collect();
+
         // Layer 2: PSR-4 convention import resolution
         // Use raw imports (unfiltered) and apply scan_root-aware external filtering
         for (test_file, source) in test_sources {
+            if l1_exclusive && layer1_matched.contains(test_file) {
+                continue;
+            }
             let raw_specifiers = Self::extract_raw_import_specifiers(source);
             let specifiers: Vec<(String, Vec<String>)> = raw_specifiers
                 .into_iter()
@@ -864,7 +874,7 @@ mod tests {
         );
 
         let mappings =
-            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path(), false);
 
         assert!(!mappings.is_empty(), "expected at least one mapping");
         let user_mapping = mappings
@@ -910,7 +920,7 @@ mod tests {
         );
 
         let mappings =
-            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path(), false);
 
         let order_mapping = mappings
             .iter()
@@ -952,7 +962,7 @@ mod tests {
         );
 
         let mappings =
-            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path(), false);
 
         // TestCase.php should not be matched to User.php
         let user_mapping = mappings
@@ -1006,7 +1016,7 @@ mod tests {
         );
 
         let mappings =
-            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path(), false);
 
         let request_mapping = mappings
             .iter()
@@ -1056,7 +1066,7 @@ mod tests {
         );
 
         let mappings =
-            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path(), false);
 
         // User.php should not have OrderTest.php mapped (no stem match, no import match)
         let user_mapping = mappings
@@ -1105,7 +1115,7 @@ mod tests {
         );
 
         let mappings =
-            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path(), false);
 
         let calc_mapping = mappings
             .iter()
@@ -1161,7 +1171,7 @@ mod tests {
         );
 
         let mappings =
-            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path(), false);
 
         let request_mapping = mappings
             .iter()
@@ -1190,7 +1200,7 @@ mod tests {
         let production_files: Vec<String> = vec![];
         let test_sources: HashMap<String, String> = HashMap::new();
         let mappings =
-            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+            ext.map_test_files_with_imports(&production_files, &test_sources, dir.path(), false);
         assert!(mappings.is_empty());
     }
 }

--- a/crates/lang-python/src/observe.rs
+++ b/crates/lang-python/src/observe.rs
@@ -817,6 +817,7 @@ impl PythonExtractor {
         production_files: &[String],
         test_sources: &HashMap<String, String>,
         scan_root: &Path,
+        l1_exclusive: bool,
     ) -> Vec<FileMapping> {
         let test_file_list: Vec<String> = test_sources.keys().cloned().collect();
 
@@ -926,6 +927,9 @@ impl PythonExtractor {
 
         // Layer 2: import tracing
         for (test_file, source) in test_sources {
+            if l1_exclusive && l1_matched_tests.contains(test_file.as_str()) {
+                continue;
+            }
             let imports = <Self as ObserveExtractor>::extract_imports(self, source, test_file);
             let from_file = Path::new(test_file);
             // all_matched: every idx matched by L2 (traditional behavior)
@@ -1853,8 +1857,12 @@ def endpoint():
             [(test_path.clone(), test_source)].into_iter().collect();
 
         // When: map_test_files_with_imports
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: module.py is matched to test_foo.py via barrel chain
         let mapping = result.iter().find(|m| m.production_file == module_path);
@@ -1907,8 +1915,12 @@ def endpoint():
             [(test_path.clone(), test_source)].into_iter().collect();
 
         // When: map_test_files_with_imports
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: module.py is matched to test_foo.py via barrel chain
         let mapping = result.iter().find(|m| m.production_file == module_path);
@@ -1968,8 +1980,12 @@ def endpoint():
             [(test_path.clone(), test_source)].into_iter().collect();
 
         // When: map_test_files_with_imports
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: module.py is NOT matched to test_nonexistent.py
         // (NonExistent is not exported by module.py)
@@ -1999,8 +2015,12 @@ def endpoint():
 
         // When: map_test_files_with_imports is called
         let scan_root = PathBuf::from(".");
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, &scan_root);
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            &scan_root,
+            false,
+        );
 
         // Then: models.py is matched to test_models.py via Layer 1 (FileNameConvention)
         let mapping = result
@@ -2052,8 +2072,12 @@ def endpoint():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, &fixture_root);
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            &fixture_root,
+            false,
+        );
 
         // Then: views.py is matched to test_views.py (Layer 2 or Layer 1)
         let mapping = result.iter().find(|m| m.production_file == views_path);
@@ -2090,8 +2114,12 @@ def endpoint():
 
         // When: map_test_files_with_imports is called
         let scan_root = PathBuf::from(".");
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, &scan_root);
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            &scan_root,
+            false,
+        );
 
         // Then: conftest.py is NOT included in any test_files list
         for mapping in &result {
@@ -2157,8 +2185,12 @@ def endpoint():
             .into_iter()
             .collect();
 
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, tmp.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
 
         ImportTestResult {
             mappings,
@@ -2529,8 +2561,12 @@ def endpoint():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, tmp.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
 
         // Then: models/cars.py is mapped via absolute import (Layer 2)
         let cars_mapping = result.iter().find(|m| m.production_file == cars_prod);
@@ -3660,8 +3696,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: module.py is matched via bare import + wildcard barrel chain
         let mapping = result.iter().find(|m| m.production_file == module_path);
@@ -3710,8 +3750,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: module.py is matched via bare import + named barrel chain
         let mapping = result.iter().find(|m| m.production_file == module_path);
@@ -3913,8 +3957,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: mod.py is mapped (Foo is accessed via pkg.Foo())
         let mod_mapping = result.iter().find(|m| m.production_file == mod_path);
@@ -3983,8 +4031,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: test_client.py is mapped to pkg/_client.py via stem-only fallback
         let mapping = result.iter().find(|m| m.production_file == client_path);
@@ -4038,8 +4090,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: test_decoders.py is mapped to pkg/_decoders.py via stem-only fallback
         //       (production_stem strips '_' prefix: "_decoders" -> "decoders")
@@ -4097,8 +4153,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: test_asgi.py is mapped to pkg/transports/asgi.py
         //       (stem "asgi" matches across directory depth)
@@ -4158,8 +4218,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: test_client.py is NOT mapped to pkg/client.py (collision guard defers to L2)
         let client_mapped = result
@@ -4223,8 +4287,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: test_client.py is mapped to svc/client.py only (L1 core match)
         let svc_client_mapped = result
@@ -4294,8 +4362,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: test_client.py is mapped to pkg/client.py only (L2 ImportTracing)
         let client_mapping = result.iter().find(|m| m.production_file == client_path);
@@ -4375,8 +4447,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: collision guard prevents L1 stem-only from mapping to both files
         //       L2 barrel import resolves to pkg/client.py (via __init__.py re-export)
@@ -4454,8 +4530,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: _client.py IS mapped (L1 stem-only match)
         let client_mapped = result
@@ -4530,8 +4610,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: _utils.py IS mapped (direct import bypasses barrel suppression)
         let utils_mapped = result
@@ -4591,8 +4675,12 @@ def test_user_detail():
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: barrel fan-out proceeds for L1-unmatched test
         //       BOTH _client.py and _utils.py should be mapped (barrel re-exports both)
@@ -4711,8 +4799,12 @@ def test_user_detail():
         let extractor = PythonExtractor::new();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Ground truth (expected TP pairs):
         // test_client.py -> _client.py  (L1 stem-only)
@@ -5030,8 +5122,12 @@ class TestMyModel(unittest.TestCase):
 
         // When: map_test_files_with_imports is called
         let extractor = PythonExtractor::new();
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, &fixture_root);
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            &fixture_root,
+            false,
+        );
 
         // Then: test_client.py maps to client.py (Client is asserted)
         let client_mapping = result.iter().find(|m| m.production_file == client_prod);
@@ -5099,8 +5195,12 @@ class TestMyModel(unittest.TestCase):
 
         // When: map_test_files_with_imports is called
         let extractor = PythonExtractor::new();
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, &fixture_root);
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            &fixture_root,
+            false,
+        );
 
         // Then: helpers.py IS mapped (fallback activated because asserted_matched is empty)
         let helpers_mapping = result.iter().find(|m| m.production_file == helpers_prod);
@@ -5162,8 +5262,12 @@ class TestMyModel(unittest.TestCase):
 
         // When: map_test_files_with_imports is called
         let extractor = PythonExtractor::new();
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, &fixture_root);
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            &fixture_root,
+            false,
+        );
 
         // Then: http_client.py IS mapped (primary SUT, must not be a FN)
         let http_client_mapping = result
@@ -5231,7 +5335,7 @@ class TestMyModel(unittest.TestCase):
 
         // When: map_test_files_with_imports is called
         let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, root);
+            extractor.map_test_files_with_imports(&production_files, &test_sources, root, false);
 
         // Then: tests/helpers.py should NOT appear as a production_file in any mapping
         for m in &mappings {
@@ -5315,7 +5419,8 @@ class TestMyModel(unittest.TestCase):
             .into_iter()
             .collect();
 
-        let result = extractor.map_test_files_with_imports(&production_files, &test_sources, root);
+        let result =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, root, false);
 
         let mock_mapping = result.iter().find(|m| m.production_file == mock_path);
         assert!(
@@ -5365,7 +5470,8 @@ class TestMyModel(unittest.TestCase):
             .into_iter()
             .collect();
 
-        let result = extractor.map_test_files_with_imports(&production_files, &test_sources, root);
+        let result =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, root, false);
 
         let version_mapping = result.iter().find(|m| m.production_file == version_path);
         assert!(
@@ -5419,7 +5525,8 @@ class TestMyModel(unittest.TestCase):
             .into_iter()
             .collect();
 
-        let result = extractor.map_test_files_with_imports(&production_files, &test_sources, root);
+        let result =
+            extractor.map_test_files_with_imports(&production_files, &test_sources, root, false);
 
         let types_mapping = result.iter().find(|m| m.production_file == types_path);
         assert!(
@@ -5510,8 +5617,12 @@ class TestMyModel(unittest.TestCase):
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: _urlparse.py IS mapped (direct import bypasses assertion filter)
         let urlparse_mapped = result
@@ -5568,8 +5679,12 @@ class TestMyModel(unittest.TestCase):
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: _internal.py IS mapped
         let internal_mapped = result
@@ -5627,8 +5742,12 @@ class TestMyModel(unittest.TestCase):
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: _helpers.py IS mapped
         let helpers_mapped = result
@@ -5692,8 +5811,12 @@ class TestMyModel(unittest.TestCase):
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: _config.py IS mapped (non-bare relative direct import bypasses assertion filter)
         let config_mapped = result
@@ -5758,8 +5881,12 @@ class TestMyModel(unittest.TestCase):
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: utils.py IS mapped (bare relative direct import bypasses assertion filter)
         let utils_mapped = result
@@ -5821,8 +5948,12 @@ class TestMyModel(unittest.TestCase):
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: _models.py is NOT mapped (barrel import, assertion filter still applies)
         let models_not_mapped = result

--- a/crates/lang-rust/src/observe.rs
+++ b/crates/lang-rust/src/observe.rs
@@ -791,6 +791,7 @@ impl RustExtractor {
         production_files: &[String],
         test_sources: &HashMap<String, String>,
         scan_root: &Path,
+        l1_exclusive: bool,
     ) -> Vec<FileMapping> {
         let test_file_list: Vec<String> = test_sources.keys().cloned().collect();
 
@@ -828,6 +829,12 @@ impl RustExtractor {
             .map(|m| m.test_files.iter().cloned().collect())
             .collect();
 
+        // Collect set of test files matched by L1 for l1_exclusive mode
+        let layer1_matched: HashSet<String> = layer1_tests_per_prod
+            .iter()
+            .flat_map(|s| s.iter().cloned())
+            .collect();
+
         // Resolve crate name for integration test import matching
         let crate_name = parse_crate_name(scan_root);
         let members = find_workspace_members(scan_root);
@@ -842,6 +849,8 @@ impl RustExtractor {
                 &canonical_root,
                 &canonical_to_idx,
                 &mut mappings,
+                l1_exclusive,
+                &layer1_matched,
             );
         }
 
@@ -866,6 +875,8 @@ impl RustExtractor {
                     &canonical_root,
                     &canonical_to_idx,
                     &mut mappings,
+                    l1_exclusive,
+                    &layer1_matched,
                 );
             }
         } else if crate_name.is_none() {
@@ -878,6 +889,8 @@ impl RustExtractor {
                 &canonical_root,
                 &canonical_to_idx,
                 &mut mappings,
+                l1_exclusive,
+                &layer1_matched,
             );
         }
 
@@ -897,6 +910,7 @@ impl RustExtractor {
     ///
     /// `crate_name`: the crate name (underscored).
     /// `crate_root`: the crate root directory (contains `Cargo.toml` and `src/`).
+    #[allow(clippy::too_many_arguments)]
     fn apply_l2_imports(
         &self,
         test_sources: &HashMap<String, String>,
@@ -905,8 +919,13 @@ impl RustExtractor {
         canonical_root: &Path,
         canonical_to_idx: &HashMap<String, usize>,
         mappings: &mut [FileMapping],
+        l1_exclusive: bool,
+        layer1_matched: &HashSet<String>,
     ) {
         for (test_file, source) in test_sources {
+            if l1_exclusive && layer1_matched.contains(test_file) {
+                continue;
+            }
             let imports = extract_import_specifiers_with_crate_name(source, Some(crate_name));
             let mut matched_indices = HashSet::<usize>::new();
 
@@ -1428,8 +1447,12 @@ mod tests {
         let test_sources: HashMap<String, String> = HashMap::new();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, tmp.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
 
         // Then: user.rs is self-mapped (Layer 0)
         let mapping = result.iter().find(|m| m.production_file == prod_path);
@@ -1456,8 +1479,12 @@ mod tests {
 
         // When: map_test_files_with_imports is called
         let scan_root = PathBuf::from(".");
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, &scan_root);
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            &scan_root,
+            false,
+        );
 
         // Then: Layer 1 stem match (same directory not required for test_stem)
         // Note: map_test_files requires same directory, but tests/ files have test_stem
@@ -1496,8 +1523,12 @@ mod tests {
             .collect();
 
         // When: map_test_files_with_imports is called
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, tmp.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
 
         // Then: service.rs is matched to test_service.rs via import tracing
         let mapping = result.iter().find(|m| m.production_file == prod_path);
@@ -1529,8 +1560,12 @@ mod tests {
 
         // When: map_test_files_with_imports is called
         let scan_root = PathBuf::from(".");
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, &scan_root);
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            &scan_root,
+            false,
+        );
 
         // Then: tests/common/mod.rs is NOT in any mapping
         for mapping in &result {
@@ -1757,8 +1792,12 @@ mod tests {
             .collect();
 
         // When: map_test_files_with_imports を呼ぶ
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, tmp.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
 
         // Then: test_user.rs → user.rs が Layer 2 (ImportTracing) でマッチ
         let mapping = result.iter().find(|m| m.production_file == prod_path);
@@ -1818,8 +1857,12 @@ mod tests {
             .collect();
 
         // When: map_test_files_with_imports を呼ぶ
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, tmp.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
 
         // Then: test_models.rs → user.rs が Layer 2 (ImportTracing) でマッチ
         let mapping = result.iter().find(|m| m.production_file == user_path);
@@ -1886,8 +1929,12 @@ mod tests {
             .collect();
 
         // When: map_test_files_with_imports を呼ぶ
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, tmp.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
 
         // Then: test_account.rs → user.rs が Layer 2 (ImportTracing) でマッチ
         // (lib.rs → models/ → pub mod user; の wildcard chain を辿る必要がある)
@@ -2323,8 +2370,12 @@ mod tests {
         .collect();
 
         // When: map_test_files_with_imports is called at workspace root
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, tmp.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
 
         // Then: test_user.rs -> user.rs via Layer 2 (ImportTracing)
         let mapping = result.iter().find(|m| m.production_file == prod_path);
@@ -2407,8 +2458,12 @@ mod tests {
         .collect();
 
         // When: map_test_files_with_imports is called at workspace root
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, tmp.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
 
         // Then: service.rs self-mapped (Layer 0) and test_service.rs mapped (Layer 1)
         let mapping = result.iter().find(|m| m.production_file == prod_path);
@@ -2494,8 +2549,12 @@ mod tests {
         .collect();
 
         // When: map_test_files_with_imports at workspace root
-        let result =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, tmp.path());
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
 
         // Then: member's test maps to member's src via L2
         let member_mapping = result.iter().find(|m| m.production_file == member_src_path);

--- a/crates/lang-typescript/src/observe.rs
+++ b/crates/lang-typescript/src/observe.rs
@@ -849,6 +849,7 @@ impl TypeScriptExtractor {
         production_files: &[String],
         test_sources: &HashMap<String, String>,
         scan_root: &Path,
+        l1_exclusive: bool,
     ) -> Vec<FileMapping> {
         let test_file_list: Vec<String> = test_sources.keys().cloned().collect();
 
@@ -895,6 +896,9 @@ impl TypeScriptExtractor {
         // Layer 2: import tracing for all test files (Layer 1 matched tests may
         // also import other production files not matched by filename convention)
         for (test_file, source) in test_sources {
+            if l1_exclusive && layer1_matched.contains(test_file) {
+                continue;
+            }
             let imports = <Self as ObserveExtractor>::extract_imports(self, source, test_file);
             let from_file = Path::new(test_file);
             let mut matched_indices = std::collections::HashSet::new();
@@ -2397,8 +2401,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: 両方のテストがマッピングされる
         assert_eq!(mappings.len(), 1, "expected 1 FileMapping");
@@ -2449,8 +2457,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: ImportTracing でマッチ
         assert_eq!(mappings.len(), 1);
@@ -2497,8 +2509,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: 未マッチ (test_files は空)
         assert_eq!(mappings.len(), 1);
@@ -2544,8 +2560,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: A と B 両方に test がマッピングされる
         assert_eq!(mappings.len(), 2, "expected 2 FileMappings (A and B)");
@@ -2942,8 +2962,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports (barrel resolution enabled)
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: foo.service.ts に foo.spec.ts がマッピングされる
         assert_eq!(mappings.len(), 1, "expected 1 FileMapping");
@@ -3002,8 +3026,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: user.service.ts にはマッピングされない (constants.ts はフィルタ済み)
         assert_eq!(
@@ -3228,8 +3256,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: foo.service.ts IS mapped to foo.spec.ts (B1 fix: namespace re-export resolved)
         let prod_mapping = mappings
@@ -3329,8 +3361,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports(scan_root=packages/core/)
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, &scan_root);
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            &scan_root,
+            false,
+        );
 
         // Then: packages/common/src/foo.ts IS mapped (symlink resolved via Layer 2c)
         let common_path_str = common_path.to_string_lossy().into_owned();
@@ -3493,8 +3529,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports with tsconfig alias present
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, &core_root);
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            &core_root,
+            false,
+        );
 
         // Then: foo.service.ts is mapped (tsconfig alias wins), common/src/foo.ts is NOT mapped
         let test_file_str = test_path.to_string_lossy().into_owned();
@@ -3578,8 +3618,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, &scan_root);
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            &scan_root,
+            false,
+        );
 
         // Then: common/src/foo.ts is mapped to BOTH test files
         let common_path_str = common_path.to_string_lossy().into_owned();
@@ -3658,8 +3702,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: route-paramtypes.enum.ts IS mapped to route.spec.ts (production-aware bypass)
         let enum_mapping = mappings
@@ -3710,8 +3758,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: user.interface.ts IS mapped to user.spec.ts (production-aware bypass)
         let iface_mapping = mappings
@@ -3788,8 +3840,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: foo.service.ts is mapped to foo.service.spec.ts via alias resolution
         let mapping = mappings
@@ -3837,8 +3893,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports (no tsconfig.json present)
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: no test_files mapped (alias import skipped without tsconfig)
         let all_test_files: Vec<&String> =
@@ -3897,8 +3957,12 @@ describe('UsersController', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: bar.service.ts is mapped via alias + barrel resolution
         let mapping = mappings
@@ -3963,8 +4027,12 @@ describe('Mixed', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: both foo.service.ts and bar.service.ts are mapped
         let foo_mapping = mappings
@@ -4030,8 +4098,12 @@ describe('Mixed', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: constants.ts is filtered by is_non_sut_helper → no test_files
         let all_test_files: Vec<&String> =
@@ -4083,8 +4155,12 @@ describe('Mixed', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports (should not panic)
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: no mapping (nonexistent.ts not in production_files), no panic
         let all_test_files: Vec<&String> =
@@ -4136,8 +4212,12 @@ describe('Mixed', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports WITH tsconfig present
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: foo.service.ts IS mapped (B3 resolved — FN → TP)
         let mapping = mappings
@@ -4197,8 +4277,12 @@ describe('Mixed', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports(scan_root=packages/core/)
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, &scan_root);
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            &scan_root,
+            false,
+        );
 
         // Then: shared.ts outside scan_root is not in production_files, so no mapping occurs.
         // `../../common/src/shared` resolves outside scan_root; it won't be in production_files
@@ -4287,8 +4371,12 @@ describe('Mixed', () => {});
         let extractor = TypeScriptExtractor::new();
 
         // When: map_test_files_with_imports
-        let mappings =
-            extractor.map_test_files_with_imports(&production_files, &test_sources, dir.path());
+        let mappings = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
 
         // Then: foo.service.ts が test_files にマッチ (Layer 2 via namespace re-export)
         let prod_mapping = mappings
@@ -4635,6 +4723,98 @@ export async function POST() { return Response.json({}); }
 
         // Then: empty Vec
         assert!(routes.is_empty(), "expected empty routes for empty source");
+    }
+
+    // TS-L1EX-01: l1_exclusive=true suppresses L2 mappings for L1-matched test files
+    #[test]
+    fn ts_l1ex_01_l1_exclusive_suppresses_l2() {
+        use tempfile::TempDir;
+
+        // Given:
+        //   production: src/user.service.ts (L1 match target)
+        //   production: src/auth.service.ts (L2 match target via import)
+        //   test: src/user.service.spec.ts
+        //     - L1 matched to user.service.ts (filename convention)
+        //     - imports auth.service.ts (would L2 match auth.service.ts)
+        let dir = TempDir::new().unwrap();
+        let src_dir = dir.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let user_service = src_dir.join("user.service.ts");
+        std::fs::File::create(&user_service).unwrap();
+        let auth_service = src_dir.join("auth.service.ts");
+        std::fs::File::create(&auth_service).unwrap();
+
+        let test_file = src_dir.join("user.service.spec.ts");
+        // This test file is L1-matched (same stem) AND imports auth.service (L2 candidate)
+        let test_source =
+            "import { AuthService } from './auth.service';\ndescribe('UserService', () => {});\n";
+
+        let production_files = vec![
+            user_service.to_string_lossy().into_owned(),
+            auth_service.to_string_lossy().into_owned(),
+        ];
+        let mut test_sources = HashMap::new();
+        test_sources.insert(
+            test_file.to_string_lossy().into_owned(),
+            test_source.to_string(),
+        );
+
+        let extractor = TypeScriptExtractor::new();
+
+        // When: l1_exclusive=true
+        let mappings_exclusive = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            true,
+        );
+
+        // Then: user.service.ts is mapped (L1), auth.service.ts is NOT mapped (L2 suppressed)
+        let user_mapping = mappings_exclusive
+            .iter()
+            .find(|m| m.production_file.contains("user.service.ts"));
+        assert!(
+            user_mapping.is_some(),
+            "expected user.service.ts in mappings, got {:?}",
+            mappings_exclusive
+        );
+        assert!(
+            !user_mapping.unwrap().test_files.is_empty(),
+            "expected user.service.ts mapped to user.service.spec.ts, got {:?}",
+            user_mapping.unwrap().test_files
+        );
+
+        let auth_mapping = mappings_exclusive
+            .iter()
+            .find(|m| m.production_file.contains("auth.service.ts"));
+        assert!(
+            auth_mapping
+                .map(|m| m.test_files.is_empty())
+                .unwrap_or(true),
+            "expected auth.service.ts NOT mapped when l1_exclusive=true, got {:?}",
+            auth_mapping
+        );
+
+        // When: l1_exclusive=false (default behavior)
+        let mappings_default = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            dir.path(),
+            false,
+        );
+
+        // Then: auth.service.ts IS mapped via L2
+        let auth_mapping_default = mappings_default
+            .iter()
+            .find(|m| m.production_file.contains("auth.service.ts"));
+        assert!(
+            auth_mapping_default
+                .map(|m| !m.test_files.is_empty())
+                .unwrap_or(false),
+            "expected auth.service.ts mapped when l1_exclusive=false, got {:?}",
+            auth_mapping_default
+        );
     }
 
     // NX-RT-08: route group in path is removed

--- a/docs/cycles/20260324_0900_l1-exclusive-mode.md
+++ b/docs/cycles/20260324_0900_l1-exclusive-mode.md
@@ -1,0 +1,31 @@
+---
+feature: "#131 L1 exclusive mode for observe"
+phase: green
+complexity: M
+test_count: 0
+risk_level: medium
+created: 2026-03-24T09:00:00Z
+updated: 2026-03-24T09:00:00Z
+---
+
+# #131 L1 exclusive mode for observe
+
+## Summary
+
+observe の L2 (import tracing) が L1 (filename convention) でマッチ済みのテストファイルに対しても追加マッピングを生成し、FP が発生する。httpx dogfooding で ~25 FP の原因。L1 マッチ済みテストは L2 を全面抑制する opt-in モードを追加する。
+
+## Implementation Notes
+
+- CLI: `--l1-exclusive` フラグ追加 (ObserveArgs)
+- 4言語の `map_test_files_with_imports()` に `l1_exclusive: bool` パラメータ追加
+- L2 ループの先頭で `l1_exclusive && layer1_matched.contains(test_file)` なら skip
+- TypeScript: `layer1_matched` (HashSet<String>)
+- Python: `l1_matched_tests` (HashSet<String>)  — `.contains(test_file.as_str())`
+- Rust: `apply_l2_imports` に `layer1_matched: &HashSet<String>` を追加
+- PHP: `layer1_tests_per_prod` から `layer1_matched` を構築して使用
+- 既存テスト全呼び出しに `false` を追加
+- 新規テスト: TypeScript で L1 exclusive テスト追加
+
+## Progress Log
+
+- 2026-03-24T09:00:00Z: GREEN phase 開始


### PR DESCRIPTION
## Summary
- Add `--l1-exclusive` CLI flag for observe: L1-matched test files skip L2 import tracing
- Reduces FP from incidental imports (httpx ~25 FP elimination)
- All 4 languages (TS/Python/Rust/PHP) updated with consistent implementation
- Also includes ROADMAP cleanup (#144 closed, Phase 23b results, Now section updated)

## Changes
- `crates/cli/src/main.rs` — `--l1-exclusive` flag in ObserveArgs
- `crates/lang-{typescript,python,rust,php}/src/observe.rs` — `l1_exclusive: bool` parameter + skip logic
- `ROADMAP.md` — updated for v0.4.3 progress

## Test plan
- [x] `cargo test` — 1142 tests pass
- [x] `cargo clippy -- -D warnings` — 0 errors
- [x] `cargo fmt --check` — no diff
- [x] `cargo run -- --lang rust .` — BLOCK 0
- [x] New test: `ts_l1ex_01` verifies L1 exclusive suppression

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)