### PR TITLE
fix: exclude barrel files from L0 inline test self-mapping (#161)

### DIFF
--- a/crates/lang-rust/src/observe.rs
+++ b/crates/lang-rust/src/observe.rs
@@ -801,6 +801,10 @@ impl RustExtractor {
 
         // Layer 0: Inline test self-mapping
         for (idx, prod_file) in production_files.iter().enumerate() {
+            // Skip barrel/entry point files (mod.rs, lib.rs, main.rs, build.rs)
+            if production_stem(prod_file).is_none() {
+                continue;
+            }
             if let Ok(source) = std::fs::read_to_string(prod_file) {
                 if detect_inline_tests(&source) {
                     // Self-map: production file maps to itself
@@ -2607,5 +2611,194 @@ mod tests {
         // No Cargo.toml
         std::fs::remove_file(tmp.path().join("Cargo.toml")).unwrap();
         assert!(!has_workspace_section(tmp.path()));
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-L0-BARREL-01: mod.rs with inline tests must NOT be self-mapped (TC-01)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_l0_barrel_01_mod_rs_excluded() {
+        // Given: mod.rs containing #[cfg(test)] in production_files
+        let tmp = tempfile::tempdir().unwrap();
+        let src_dir = tmp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let mod_rs = src_dir.join("mod.rs");
+        std::fs::write(
+            &mod_rs,
+            r#"pub mod sub;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_something() {}
+}
+"#,
+        )
+        .unwrap();
+
+        let extractor = RustExtractor::new();
+        let prod_path = mod_rs.to_string_lossy().into_owned();
+        let production_files = vec![prod_path.clone()];
+        let test_sources: HashMap<String, String> = HashMap::new();
+
+        // When: map_test_files_with_imports is called
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
+
+        // Then: mod.rs is NOT self-mapped (barrel file exclusion)
+        let mapping = result.iter().find(|m| m.production_file == prod_path);
+        assert!(mapping.is_some());
+        assert!(
+            !mapping.unwrap().test_files.contains(&prod_path),
+            "mod.rs should NOT be self-mapped, but found in: {:?}",
+            mapping.unwrap().test_files
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-L0-BARREL-02: lib.rs with inline tests must NOT be self-mapped (TC-02)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_l0_barrel_02_lib_rs_excluded() {
+        // Given: lib.rs containing #[cfg(test)] in production_files
+        let tmp = tempfile::tempdir().unwrap();
+        let src_dir = tmp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let lib_rs = src_dir.join("lib.rs");
+        std::fs::write(
+            &lib_rs,
+            r#"pub mod utils;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_lib() {}
+}
+"#,
+        )
+        .unwrap();
+
+        let extractor = RustExtractor::new();
+        let prod_path = lib_rs.to_string_lossy().into_owned();
+        let production_files = vec![prod_path.clone()];
+        let test_sources: HashMap<String, String> = HashMap::new();
+
+        // When: map_test_files_with_imports is called
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
+
+        // Then: lib.rs is NOT self-mapped (barrel file exclusion)
+        let mapping = result.iter().find(|m| m.production_file == prod_path);
+        assert!(mapping.is_some());
+        assert!(
+            !mapping.unwrap().test_files.contains(&prod_path),
+            "lib.rs should NOT be self-mapped, but found in: {:?}",
+            mapping.unwrap().test_files
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-L0-BARREL-03: regular .rs file with inline tests IS self-mapped (TC-03, regression)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_l0_barrel_03_regular_file_self_mapped() {
+        // Given: a regular .rs file (not a barrel) containing #[cfg(test)]
+        let tmp = tempfile::tempdir().unwrap();
+        let src_dir = tmp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let service_rs = src_dir.join("service.rs");
+        std::fs::write(
+            &service_rs,
+            r#"pub fn do_work() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_do_work() { assert!(true); }
+}
+"#,
+        )
+        .unwrap();
+
+        let extractor = RustExtractor::new();
+        let prod_path = service_rs.to_string_lossy().into_owned();
+        let production_files = vec![prod_path.clone()];
+        let test_sources: HashMap<String, String> = HashMap::new();
+
+        // When: map_test_files_with_imports is called
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
+
+        // Then: service.rs IS self-mapped (regular file with inline tests)
+        let mapping = result.iter().find(|m| m.production_file == prod_path);
+        assert!(mapping.is_some());
+        assert!(
+            mapping.unwrap().test_files.contains(&prod_path),
+            "service.rs should be self-mapped, but not found in: {:?}",
+            mapping.unwrap().test_files
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-L0-BARREL-04: main.rs with inline tests must NOT be self-mapped (TC-04)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_l0_barrel_04_main_rs_excluded() {
+        // Given: main.rs containing #[cfg(test)] in production_files
+        let tmp = tempfile::tempdir().unwrap();
+        let src_dir = tmp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let main_rs = src_dir.join("main.rs");
+        std::fs::write(
+            &main_rs,
+            r#"fn main() {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_main() {}
+}
+"#,
+        )
+        .unwrap();
+
+        let extractor = RustExtractor::new();
+        let prod_path = main_rs.to_string_lossy().into_owned();
+        let production_files = vec![prod_path.clone()];
+        let test_sources: HashMap<String, String> = HashMap::new();
+
+        // When: map_test_files_with_imports is called
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
+
+        // Then: main.rs is NOT self-mapped (entry point file exclusion)
+        let mapping = result.iter().find(|m| m.production_file == prod_path);
+        assert!(mapping.is_some());
+        assert!(
+            !mapping.unwrap().test_files.contains(&prod_path),
+            "main.rs should NOT be self-mapped, but found in: {:?}",
+            mapping.unwrap().test_files
+        );
     }
 }

--- a/docs/cycles/20260324_1042_rust-l1-barrel-self-mapping-fix.md
+++ b/docs/cycles/20260324_1042_rust-l1-barrel-self-mapping-fix.md
@@ -1,0 +1,139 @@
+---
+feature: "#161 Rust L1 safeguards: mod.rs exclusion + test file existence check"
+cycle: 20260324_1042
+phase: COMMIT
+complexity: standard
+test_count: 4
+risk_level: low
+codex_session_id: ""
+created: 2026-03-24 10:42
+updated: 2026-03-24
+---
+
+# #161 Rust L1 safeguards: mod.rs exclusion + test file existence check
+
+## Summary
+
+GT audit (#149) で Rust observe P=76.7% (7/30 FP)。Issue #161 は L1 filename matching の FP 排除を目的とするが、コード調査の結果、Issue の記述と実装に矛盾がある。実際の FP は L0 (inline test detection) の self-mapping から発生している。mod.rs/lib.rs/main.rs 等の barrel ファイルが `#[cfg(test)]` を持つ場合に自身をマッピングするのを抑制する。
+
+## Scope Definition
+
+### In Scope
+
+- `crates/lang-rust/src/observe.rs`: L0 self-mapping に `production_stem()` チェック追加 (L802-812)
+- 新規テスト: mod.rs/lib.rs/main.rs の self-mapping が除外されることを検証
+- Issue #161 へのコメント: 根本原因の修正報告
+
+### Out of Scope
+
+- L2 incidental import FP (Issue #163 で別途対応)
+- tokio 50-pair re-audit (Issue #163)
+- テストファイル存在チェック (`map_test_files()` は構造的に不要と確認)
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `crates/lang-rust/src/observe.rs` | L0 self-mapping に barrel filter 追加 (L802-812 付近) |
+| `crates/lang-rust/src/observe.rs` (tests) | 新規テスト追加 |
+
+## Environment
+
+- Layer: lang-rust/observe
+- Plugin: Rust
+- Risk: low
+- Runtime: Rust (cargo test)
+- Dependencies: tree-sitter, lang-rust crate
+
+## Context & Dependencies
+
+### Root Cause Analysis
+
+| Issue の主張 | 実コード |
+|-------------|---------|
+| `production_stem()` が "mod" を返す | `stem == "mod"` → `None` (既に除外済み, lang-rust/observe.rs:82) |
+| L1 がテスト不在ファイルをマッチ | `map_test_files()` は test_files リスト内のみマッチ (core/observe.rs:103-117) |
+
+実際の FP は `map_test_files_with_imports()` の L0 セクション (lang-rust/observe.rs:802-812) が、`detect_inline_tests()` で `#[cfg(test)]` を検出した全 production file を self-map することで発生。mod.rs/lib.rs でも `#[cfg(test)]` があれば self-mapping される。
+
+### FP Examples (tokio dogfooding)
+
+```
+tokio-util/src/sync/mod.rs → 自身  (strategy: filename)
+tokio/src/fs/mod.rs → 自身
+tokio/src/runtime/mod.rs → 自身
+tokio/src/runtime/task/mod.rs → 自身
+tokio/src/runtime/time/mod.rs → 自身
+tokio/src/runtime/time_alt/mod.rs → 自身
+tokio/src/sync/mod.rs → 自身
+tokio/src/lib.rs → 自身
+```
+
+### References
+
+- CONSTITUTION.md Section 7: "exspec errs on the side of being quiet"
+- ROADMAP.md: Phase 1 (L1 safeguards) の目的と一致
+- observe-gt-guideline.md: barrel file (mod.rs) は non_target
+
+## Implementation Notes
+
+### Goal
+
+tokio の mod.rs/lib.rs self-mapping FP (~6-8件) を排除。30-pair サンプルの L1 FP (5件中 4-5件) 解消。P 76.7% → ~87-93% (推定)。
+
+### Background
+
+GT audit (#149) で Rust observe の Precision が 76.7% (7/30 FP)。Issue #161 が作成されたが、Issue の Proposed Solution は実コードと矛盾していた。コード調査により真の FP メカニズムが L0 self-mapping にあることが判明。
+
+### Design Approach
+
+`map_test_files_with_imports()` の L0 セクションで、`production_stem()` が `None` を返すファイル (mod.rs, lib.rs, main.rs, build.rs) の self-mapping をスキップ。
+
+```rust
+// Layer 0: Inline test self-mapping
+for (idx, prod_file) in production_files.iter().enumerate() {
+    // Skip barrel/entry point files (mod.rs, lib.rs, main.rs, build.rs)
+    if self.production_stem(prod_file).is_none() {
+        continue;
+    }
+    if let Ok(source) = std::fs::read_to_string(prod_file) {
+        if detect_inline_tests(&source) {
+            if !mappings[idx].test_files.contains(prod_file) {
+                mappings[idx].test_files.push(prod_file.clone());
+            }
+        }
+    }
+}
+```
+
+**Note**: 一部の mod.rs は barrel ではなく実ロジック + inline tests を持つ可能性があるが (e.g., `tokio/src/runtime/time_alt/mod.rs`)、CONSTITUTION の quiet 原則 (FP を避ける方向にエラー) に沿い、mod.rs self-mapping は除外する。
+
+## Test List
+
+### TODO
+
+(none)
+
+### WIP
+
+(none)
+
+### DONE
+
+- [x] TC-01: **Given** mod.rs with `#[cfg(test)]` in production_files, **When** map_test_files_with_imports, **Then** mod.rs は self-mapping されない → `rs_l0_barrel_01_mod_rs_excluded` (RED: FAIL)
+- [x] TC-02: **Given** lib.rs with `#[cfg(test)]` in production_files, **When** map_test_files_with_imports, **Then** lib.rs は self-mapping されない → `rs_l0_barrel_02_lib_rs_excluded` (RED: FAIL)
+- [x] TC-03: **Given** regular .rs file with `#[cfg(test)]`, **When** map_test_files_with_imports, **Then** self-mapping される (regression) → `rs_l0_barrel_03_regular_file_self_mapped` (RED: PASS as expected)
+- [x] TC-04: **Given** main.rs with `#[cfg(test)]`, **When** map_test_files_with_imports, **Then** main.rs は self-mapping されない → `rs_l0_barrel_04_main_rs_excluded` (RED: FAIL)
+
+### DISCOVERED
+
+(none)
+
+## Progress Log
+
+- 2026-03-24 10:42: Cycle doc 作成 (sync-plan)
+- 2026-03-24 10:50: REVIEW (plan) WARN score:35. FN risk for logic-carrying mod.rs noted (runtime/task/mod.rs 31fn, runtime/time/mod.rs 11fn). CONSTITUTION quiet原則で FP 優先、FN は #163 re-audit で定量評価。TC-04 main.rs は production_files に含まれることを確認。Phase completed.
+- 2026-03-24: RED phase completed. 4 tests added to crates/lang-rust/src/observe.rs. TC-01/TC-02/TC-04 FAIL (expected RED), TC-03 PASS (regression). clippy clean.
+- 2026-03-24: GREEN phase completed. L0 self-mapping に production_stem() チェック追加 (2行)。全4テスト PASS。
+- 2026-03-24: REFACTOR phase completed. チェックリスト走査、改善不要。Verification Gate PASS (1146 tests, clippy 0, fmt clean, self-dogfooding BLOCK 0). Phase completed.
+- 2026-03-24: REVIEW (code) PASS score:8. Security PASS(5), Correctness PASS(8), Lint PASS(0). No blocking issues. Phase completed.


### PR DESCRIPTION
## Summary

- Rust observe L0 (inline test detection) が mod.rs/lib.rs/main.rs の `#[cfg(test)]` で self-mapping を生成し、FP の原因になっていた
- `production_stem()` ガードを追加し、barrel/entry point ファイルの self-mapping をスキップ
- tokio dogfooding で ~6-8件の barrel self-mapping FP を排除

## Root Cause Analysis

Issue #161 の記述 (`production_stem()` が "mod" を返す) は実コードと矛盾。実際の FP は L0 self-mapping から発生していた。

## Test plan

- [x] TC-01: mod.rs with `#[cfg(test)]` is NOT self-mapped
- [x] TC-02: lib.rs with `#[cfg(test)]` is NOT self-mapped
- [x] TC-03: Regular .rs file with `#[cfg(test)]` IS self-mapped (regression)
- [x] TC-04: main.rs with `#[cfg(test)]` is NOT self-mapped
- [x] `cargo test` (1146 tests pass)
- [x] `cargo clippy -- -D warnings` (0 errors)
- [x] `cargo fmt --check` (clean)
- [x] Self-dogfooding: BLOCK 0

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)