### PR TITLE
docs: Rust 50-pair re-audit results (P=92.0%, #163)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,9 +15,9 @@ Goal: Rust (P=76.7%) と PHP (P=90.0%) の observe precision を改善する。s
 
 | Issue | Task | Type | Expected Impact |
 |-------|------|------|-----------------|
-| #161 | Rust L1 safeguards: mod.rs除外 + テストファイル存在検証 | observe precision | Rust P 76.7% → ~90% (4 FP 排除) |
-| #163 | Rust L1 fix → re-audit (50-pair, tokio) | observe validation | 中間計測。結果次第で #162 の Go/No-Go |
-| #162 | Rust L2 re-export chain validation (conditional) | observe precision | Rust P ~90% → ~97% (2 FP 排除。re-audit 後に判断) |
+| #161 | ~~Rust L0 barrel self-mapping exclusion~~ | observe precision | **DONE** Rust P 76.7% → 92.0% (+15.3pp) |
+| #163 | ~~Rust 中間 re-audit (50-pair, tokio)~~ | observe validation | **DONE** P=92.0% (46/50). #162 GO判定 |
+| #162 | Rust L2 re-export chain validation + L0 detect_inline_tests 改善 | observe precision | Rust P 92.0% → ~98% (4 FP 排除) |
 | #129 | PHP L2 fan-out filter (高頻度utility class抑制) | observe precision | PHP P 90.0% → ~97% (Str, Collection 等の除外) |
 | #163 | Final re-audit (50-pair, tokio + laravel + symfony) | observe validation | ship criteria 最終判定 |
 
@@ -29,15 +29,16 @@ Goal: Rust (P=76.7%) と PHP (P=90.0%) の observe precision を改善する。s
 
 ### Rust observe precision improvement
 
-GT audit FP内訳 (7/30):
-- **L1 mod.rs collision** (1): `production_stem()` が mod を返し、テスト側 mod.rs と衝突
-- **L1 テストファイル不在** (3): L1 がファイル名一致を仮定するが、実際にはテストファイルが存在しない
-- **L1 barrel mismatch** (1): lib.rs/mod.rs がproduction fileとして不適切にマッチ
-- **L2 re-export confusion** (2): `pub mod` chain で wrapper と実体を混同
+**Phase 1 DONE** (#161): L0 barrel self-mapping exclusion。`production_stem()` が None のファイル (mod.rs, lib.rs, main.rs) の self-mapping をスキップ。P 76.7% → 92.0% (+15.3pp)。
 
-**Phase 1** (L1 safeguards): `map_test_files()` で (a) mod.rs を L1 候補から除外、(b) テストファイルリストとの照合を追加。予想: **4 FP 排除 → 27/30 = P 90.0%**。その後 50-pair re-audit で中間計測。
+50-pair re-audit (#163) FP内訳 (4/50):
+- **L0 cfg(test) false detection** (2): source.rs (helper method用), open_options.rs (mock切替用) — `#[cfg(test)]` がテストモジュール以外の条件付きコンパイルに使われているケース
+- **L2 re-export chain confusion** (2): driver.rs ← shutdown.rs/yield_now.rs — `pub(crate) mod driver` in runtime/mod.rs で `crate::runtime::*` をimportするテストが driver.rs にマッピングされる
 
-**Phase 2** (L2 re-export, conditional): Phase 1 の re-audit で P < 98% なら `file_exports_any_symbol()` を L2 マッチ時に検証。予想: **2 FP 排除 → ~29/30 = P ~97%**。P >= 98% なら Phase 2 はスキップ。
+**Phase 2** (#162, GO判定): 2つの改善が必要:
+1. **L0 detect_inline_tests 改善**: `#[cfg(test)]` の後に実際の `mod tests` ブロックがあるかチェック (2 FP 排除)
+2. **L2 re-export validation**: `file_exports_any_symbol()` で production file がテストで使われるシンボルを実際にexportしているか検証 (2 FP 排除)
+予想: **4 FP 排除 → 50/50 = P 100%**。
 
 ### PHP observe precision improvement
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,9 +2,9 @@
 
 ## Current Phase
 
-v0.4.3 release. Same-file helper tracing (all 4 languages), L1 exclusive mode, GT audit completed.
+v0.4.4-dev. #161 L0 barrel exclusion完了、中間re-audit実施。
 
-observe TypeScript: P=100%, R=91% (stable). Python: P=98.2%, R=96.8% (stable). Rust: P=76.7% (experimental, GT audit FAIL). PHP: P=90.0% (experimental, GT audit FAIL). Lint: 17 active rules, 4 languages, same-file helper tracing enabled. Default output: ai-prompt.
+observe TypeScript: P=100%, R=91% (stable). Python: P=98.2%, R=96.8% (stable). Rust: P=92.0% (experimental, 50-pair re-audit FAIL, +15.3pp from 76.7%). PHP: P=90.0% (experimental, GT audit FAIL). Lint: 17 active rules, 4 languages, same-file helper tracing enabled. Default output: ai-prompt.
 
 ## Progress
 

--- a/docs/dogfooding-results.md
+++ b/docs/dogfooding-results.md
@@ -1,7 +1,34 @@
 # Dogfooding Results
 
-Latest: 2026-03-24, exspec v0.4.3-dev (helper tracing + L1 exclusive + GT audit)
+Latest: 2026-03-24, exspec v0.4.3-dev (post-#161 L0 barrel exclusion + re-audit)
 Initial: 2026-03-09, exspec v0.1.0 (commit 5957cd0)
+
+## Rust Re-audit: Post-#161 (50-pair, tokio, 2026-03-24)
+
+Ship criteria: P>=98% (49/50)
+
+| Metric | Value | Target | Result |
+|--------|-------|--------|--------|
+| Precision | **92.0%** (46/50) | >= 98% | **FAIL** |
+| Recall (test file) | **36.8%** (100/272) | >= 90% | **FAIL** (unchanged) |
+
+FP causes (4/50):
+- L0 cfg(test) false detection (2): source.rs (helper method), open_options.rs (mock substitution) — `#[cfg(test)]` used for conditional compilation, not test modules
+- L2 re-export chain confusion (2): driver.rs ← shutdown.rs, driver.rs ← yield_now.rs — `pub(crate) mod driver` in runtime/mod.rs causes any `use crate::runtime::*` test to map to driver.rs
+
+### vs v0.4.3 audit
+
+| Metric | v0.4.3 (30-pair) | Post-#161 (50-pair) | Delta |
+|--------|------------------|---------------------|-------|
+| Precision | 76.7% (23/30) | **92.0%** (46/50) | **+15.3pp** |
+
+#161 eliminated mod.rs/lib.rs barrel self-mapping FPs. Remaining FPs are:
+1. **L0 detect_inline_tests false positive**: `#[cfg(test)]` used for conditional compilation (helper methods, mock substitution) is indistinguishable from `#[cfg(test)] mod tests`
+2. **L2 re-export chain**: `pub(crate) mod` makes all sub-modules visible to import tracing, causing over-mapping
+
+### Decision: #162 (L2 re-export validation) is GO
+
+P=92.0% < 98%. L2 FPs (2/4) can be addressed by `file_exports_any_symbol()` validation. L0 FPs (2/4) require smarter `detect_inline_tests()` that checks for actual `mod tests` blocks, not just `#[cfg(test)]`.
 
 ## GT Audit: Rust/PHP Observe (#149, 2026-03-24)
 


### PR DESCRIPTION
## Summary

- Post-#161 Rust observe re-audit on tokio workspace (50-pair sample)
- Precision: 76.7% -> **92.0%** (+15.3pp)
- 4 remaining FPs identified: 2 L0 (cfg_test false detection), 2 L2 (re-export confusion)
- Decision: #162 (L2 re-export + L0 improvement) is **GO**

## Test plan

- [x] 50-pair random sample (seed=42) from tokio observe output
- [x] Each pair manually verified against GT guideline
- [x] FP causes documented with specific file pairs
- [x] ROADMAP/STATUS updated with results

Ref #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)