### PR TITLE
feat: L0 detect_inline_tests mod_item check + L2 export symbol filter (#162)

### DIFF
--- a/crates/lang-rust/src/observe.rs
+++ b/crates/lang-rust/src/observe.rs
@@ -143,6 +143,7 @@ pub fn detect_inline_tests(source: &str) -> bool {
 
     let attr_name_idx = query.capture_index_for_name("attr_name");
     let cfg_arg_idx = query.capture_index_for_name("cfg_arg");
+    let cfg_test_attr_idx = query.capture_index_for_name("cfg_test_attr");
 
     let mut cursor = QueryCursor::new();
     let mut matches = cursor.matches(query, tree.root_node(), source_bytes);
@@ -150,6 +151,7 @@ pub fn detect_inline_tests(source: &str) -> bool {
     while let Some(m) = matches.next() {
         let mut is_cfg = false;
         let mut is_test = false;
+        let mut attr_node: Option<tree_sitter::Node> = None;
 
         for cap in m.captures {
             let text = cap.node.utf8_text(source_bytes).unwrap_or("");
@@ -159,10 +161,25 @@ pub fn detect_inline_tests(source: &str) -> bool {
             if cfg_arg_idx == Some(cap.index) && text == "test" {
                 is_test = true;
             }
+            if cfg_test_attr_idx == Some(cap.index) {
+                attr_node = Some(cap.node);
+            }
         }
 
         if is_cfg && is_test {
-            return true;
+            // Verify that the next sibling (skipping other attribute_items) is a mod_item
+            if let Some(attr) = attr_node {
+                let mut sibling = attr.next_sibling();
+                while let Some(s) = sibling {
+                    if s.kind() == "mod_item" {
+                        return true;
+                    }
+                    if s.kind() != "attribute_item" {
+                        break;
+                    }
+                    sibling = s.next_sibling();
+                }
+            }
         }
     }
 
@@ -942,14 +959,22 @@ impl RustExtractor {
                     &src_relative,
                     canonical_root,
                 ) {
+                    let mut per_specifier_indices = HashSet::<usize>::new();
                     exspec_core::observe::collect_import_matches(
                         self,
                         &resolved,
                         symbols,
                         canonical_to_idx,
-                        &mut matched_indices,
+                        &mut per_specifier_indices,
                         canonical_root,
                     );
+                    // Filter: if symbols are specified, only include files that export them
+                    for idx in per_specifier_indices {
+                        let prod_path = Path::new(&mappings[idx].production_file);
+                        if self.file_exports_any_symbol(prod_path, symbols) {
+                            matched_indices.insert(idx);
+                        }
+                    }
                 }
             }
 
@@ -2798,6 +2823,222 @@ mod tests {
         assert!(
             !mapping.unwrap().test_files.contains(&prod_path),
             "main.rs should NOT be self-mapped, but found in: {:?}",
+            mapping.unwrap().test_files
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-L0-DETECT-01: #[cfg(test)] mod tests {} -> detect_inline_tests = true
+    // (REGRESSION: should PASS with current implementation)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_l0_detect_01_cfg_test_with_mod_block() {
+        // Given: source with #[cfg(test)] followed by mod tests { ... }
+        let source = r#"
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add() {
+        assert_eq!(add(1, 2), 3);
+    }
+}
+"#;
+        // When: detect_inline_tests is called
+        // Then: returns true (real inline test module)
+        assert!(detect_inline_tests(source));
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-L0-DETECT-02: #[cfg(test)] for helper method (no mod) -> false
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_l0_detect_02_cfg_test_for_helper_method() {
+        // Given: source with #[cfg(test)] applied to a function (not a mod)
+        let source = r#"
+pub struct Connection;
+
+impl Connection {
+    #[cfg(test)]
+    pub fn test_helper(&self) -> bool {
+        true
+    }
+}
+"#;
+        // When: detect_inline_tests is called
+        // Then: returns false (cfg(test) does not annotate a mod_item)
+        assert!(!detect_inline_tests(source));
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-L0-DETECT-03: #[cfg(test)] for mock substitution (use statement) -> false
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_l0_detect_03_cfg_test_for_use_statement() {
+        // Given: source with #[cfg(test)] applied to a use statement (mock substitution)
+        let source = r#"
+#[cfg(not(test))]
+use real_http::Client;
+
+#[cfg(test)]
+use mock_http::Client;
+
+pub fn fetch(url: &str) -> String {
+    Client::get(url)
+}
+"#;
+        // When: detect_inline_tests is called
+        // Then: returns false (cfg(test) annotates a use item, not a mod_item)
+        assert!(!detect_inline_tests(source));
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-L0-DETECT-04: #[cfg(test)] mod tests; (external module ref) -> true
+    // (REGRESSION: should PASS with current implementation)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_l0_detect_04_cfg_test_with_external_mod_ref() {
+        // Given: source with #[cfg(test)] followed by mod tests; (semicolon form)
+        let source = r#"
+pub fn compute(x: i32) -> i32 { x * 2 }
+
+#[cfg(test)]
+mod tests;
+"#;
+        // When: detect_inline_tests is called
+        // Then: returns true (mod_item via external module reference)
+        assert!(detect_inline_tests(source));
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-L2-EXPORT-FILTER-01: test imports symbol directly from module path,
+    // module file does NOT export that symbol -> file NOT mapped
+    //
+    // Scenario: use myapp::runtime::driver::{Builder}
+    // driver.rs resolves directly (non-barrel), does NOT export Builder.
+    // collect_import_matches() else-branch currently maps it without symbol check.
+    // apply_l2_imports() should filter via file_exports_any_symbol().
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_l2_export_filter_01_no_export_not_mapped() {
+        // Given: temp directory mimicking a crate with:
+        //   src/runtime/driver.rs: exports spawn() and Driver, NOT Builder
+        //   tests/test_runtime.rs: use myapp::runtime::driver::{Builder}
+        let tmp = tempfile::tempdir().unwrap();
+        let src_runtime = tmp.path().join("src").join("runtime");
+        let tests_dir = tmp.path().join("tests");
+        std::fs::create_dir_all(&src_runtime).unwrap();
+        std::fs::create_dir_all(&tests_dir).unwrap();
+
+        // Cargo.toml
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"myapp\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+
+        // src/runtime/driver.rs - exports spawn() and Driver, NOT Builder
+        let driver_rs = src_runtime.join("driver.rs");
+        std::fs::write(&driver_rs, "pub fn spawn() {}\npub struct Driver;\n").unwrap();
+
+        // tests/test_runtime.rs - imports Builder directly from runtime::driver
+        // driver.rs resolves as a non-barrel file (no mod.rs lookup needed)
+        let test_rs = tests_dir.join("test_runtime.rs");
+        let test_source = "use myapp::runtime::driver::{Builder};\n\n#[test]\nfn test_build() {}\n";
+        std::fs::write(&test_rs, test_source).unwrap();
+
+        let extractor = RustExtractor::new();
+        let driver_path = driver_rs.to_string_lossy().into_owned();
+        let test_path = test_rs.to_string_lossy().into_owned();
+        let production_files = vec![driver_path.clone()];
+        let test_sources: HashMap<String, String> = [(test_path.clone(), test_source.to_string())]
+            .into_iter()
+            .collect();
+
+        // When: map_test_files_with_imports is called
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
+
+        // Then: driver.rs is NOT mapped to test_runtime.rs
+        // (driver.rs does not export Builder — apply_l2_imports must filter it)
+        let mapping = result.iter().find(|m| m.production_file == driver_path);
+        if let Some(m) = mapping {
+            assert!(
+                !m.test_files.contains(&test_path),
+                "driver.rs should NOT be mapped (does not export Builder), but found: {:?}",
+                m.test_files
+            );
+        }
+        // If no mapping entry exists at all, that is also acceptable
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-L2-EXPORT-FILTER-02: barrel with pub mod service, test imports
+    // ServiceFn which service.rs DOES export -> service.rs IS mapped
+    // (REGRESSION: should PASS with current implementation)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_l2_export_filter_02_exports_symbol_is_mapped() {
+        // Given: temp directory mimicking a crate with:
+        //   src/app/mod.rs: pub mod service;
+        //   src/app/service.rs: exports pub fn service_fn()
+        //   tests/test_app.rs: use myapp::app::{service_fn}
+        let tmp = tempfile::tempdir().unwrap();
+        let src_app = tmp.path().join("src").join("app");
+        let tests_dir = tmp.path().join("tests");
+        std::fs::create_dir_all(&src_app).unwrap();
+        std::fs::create_dir_all(&tests_dir).unwrap();
+
+        // Cargo.toml
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"myapp\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+
+        // src/app/mod.rs - pub mod service
+        let mod_rs = src_app.join("mod.rs");
+        std::fs::write(&mod_rs, "pub mod service;\n").unwrap();
+
+        // src/app/service.rs - exports service_fn
+        let service_rs = src_app.join("service.rs");
+        std::fs::write(&service_rs, "pub fn service_fn() {}\n").unwrap();
+
+        // tests/test_app.rs - imports service_fn from app
+        let test_rs = tests_dir.join("test_app.rs");
+        let test_source = "use myapp::app::{service_fn};\n\n#[test]\nfn test_service() {}\n";
+        std::fs::write(&test_rs, test_source).unwrap();
+
+        let extractor = RustExtractor::new();
+        let service_path = service_rs.to_string_lossy().into_owned();
+        let test_path = test_rs.to_string_lossy().into_owned();
+        let production_files = vec![service_path.clone()];
+        let test_sources: HashMap<String, String> = [(test_path.clone(), test_source.to_string())]
+            .into_iter()
+            .collect();
+
+        // When: map_test_files_with_imports is called
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
+
+        // Then: service.rs IS mapped to test_app.rs
+        // (service.rs exports service_fn which the test imports)
+        let mapping = result.iter().find(|m| m.production_file == service_path);
+        assert!(mapping.is_some(), "service.rs should have a mapping entry");
+        assert!(
+            mapping.unwrap().test_files.contains(&test_path),
+            "service.rs should be mapped to test_app.rs, got: {:?}",
             mapping.unwrap().test_files
         );
     }

--- a/docs/cycles/20260324_1119_rust-l2-reexport-chain-and-l0-inline-test-fix.md
+++ b/docs/cycles/20260324_1119_rust-l2-reexport-chain-and-l0-inline-test-fix.md
@@ -1,0 +1,141 @@
+---
+feature: "#162 Rust L2 re-export chain validation + L0 detect_inline_tests improvement"
+cycle: 20260324_1119
+phase: COMMIT
+complexity: standard
+test_count: 6
+risk_level: low
+codex_session_id: ""
+created: 2026-03-24 11:19
+updated: 2026-03-24 11:19
+---
+
+# #162 Rust L2 re-export chain validation + L0 detect_inline_tests improvement
+
+## Summary
+
+Issue #163 の中間 re-audit で P=92.0% (46/50)。残存 FP 4件を排除し P=100% (50/50) を目指す。FP の内訳は L0 cfg(test) false detection 2件 (source.rs, open_options.rs — `#[cfg(test)]` がテストモジュール以外の用途) と L2 re-export chain confusion 2件 (driver.rs ← shutdown.rs/yield_now.rs — `pub(crate) mod` 経由の over-mapping)。
+
+## Scope Definition
+
+### In Scope
+
+- `crates/lang-rust/src/observe.rs:135-170`: `detect_inline_tests()` に `mod_item` 兄弟ノード検証追加
+- `crates/lang-rust/src/observe.rs:918-962`: `apply_l2_imports()` に `file_exports_any_symbol()` フィルタ追加
+- `crates/lang-rust/src/observe.rs` (tests): 新規テスト6件追加
+
+### Out of Scope
+
+- L0 FN: `#[cfg(test)] mod helper_utils;` のような非 `tests` 名モジュール (現行と同じ挙動を維持)
+- L2 FN: symbols が空の import はフィルタリングしない (短絡評価、現行維持)
+- `core/observe.rs` の `collect_import_matches()` は直接変更しない
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `crates/lang-rust/src/observe.rs:135-170` | `detect_inline_tests` に `mod_item` 検証追加 |
+| `crates/lang-rust/src/observe.rs:918-962` | `apply_l2_imports` に `file_exports_any_symbol` フィルタ追加 |
+| `crates/lang-rust/src/observe.rs` (tests) | 新規テスト6件追加 |
+
+## Environment
+
+- Layer: lang-rust/observe
+- Plugin: Rust
+- Risk: low
+- Runtime: Rust (cargo test)
+- Dependencies: tree-sitter, lang-rust crate
+
+## Risk Interview
+
+- **L0 FN risk**: `#[cfg(test)] mod helper_utils;` のような非 `tests` 名モジュールも inline test として検出される (現行と同じ)。mod_item 検証のみで名前制限はしない。
+- **L2 FN risk**: `file_exports_any_symbol()` は symbols が空のとき true を返す (短絡評価)。symbols 付きの import のみフィルタリング。
+
+## Context & Dependencies
+
+### Upstream References
+
+- CONSTITUTION.md Section 7: quiet 原則 (FP を避ける方向)
+- ROADMAP.md: Phase 2 — L2 re-export validation (GO 判定済み)
+- Re-audit data: dogfooding-results.md の 50-pair 結果
+
+## Implementation Notes
+
+### Goal
+
+残存 FP 4件を全排除。P=92.0% (46/50) → P=100% (50/50)。
+
+### Background
+
+Issue #163 中間 re-audit 結果:
+
+- L0 cfg(test) false detection (2件): source.rs, open_options.rs — `#[cfg(test)]` がテストモジュール以外の用途で使われているケース
+- L2 re-export chain confusion (2件): driver.rs ← shutdown.rs/yield_now.rs — `pub(crate) mod` 経由の over-mapping
+
+### Design Approach
+
+#### Fix A: L0 detect_inline_tests improvement
+
+`detect_inline_tests()` (lang-rust/observe.rs:135-170) は `#[cfg(test)]` 属性を検出するだけで、次の兄弟ノードが `mod_item` (テストモジュール) かどうかを確認しない。
+
+`find_cfg_test_ranges()` (同ファイル:398-453) にある兄弟ノード走査パターンを再利用:
+
+```rust
+pub fn detect_inline_tests(source: &str) -> bool {
+    // ... existing tree-sitter parse + query ...
+    if is_cfg && is_test {
+        // NEW: verify next sibling is a mod_item
+        if let Some(attr) = attr_node {
+            let mut sibling = attr.next_sibling();
+            while let Some(s) = sibling {
+                if s.kind() == "mod_item" {
+                    return true;  // Real inline test module
+                }
+                if s.kind() != "attribute_item" {
+                    break;  // Next non-attribute item is not a mod
+                }
+                sibling = s.next_sibling();
+            }
+        }
+    }
+    // ... continue loop, return false at end
+}
+```
+
+#### Fix B: L2 file_exports_any_symbol validation
+
+`apply_l2_imports()` → `collect_import_matches()` が barrel re-export chain を辿り、`pub(crate) mod driver` 経由で driver.rs をマッピングするが、driver.rs は Builder/Handle をexportしていない。
+
+`apply_l2_imports()` (lang-rust/observe.rs:918-962) の中で、`collect_import_matches()` の結果に対して `file_exports_any_symbol()` でフィルタリング。具体的には: `collect_import_matches()` が返す各ファイルに対し、symbols が空でなければ `self.file_exports_any_symbol(&path, &symbols)` を確認。false なら mapping に追加しない。
+
+## Test List
+
+### TODO
+
+- [x] TC-01: **Given** file with `#[cfg(test)]` followed by `mod tests {}`, **When** detect_inline_tests, **Then** true (regression) — PASS ✓
+- [x] TC-02: **Given** file with `#[cfg(test)]` for helper method (no mod), **When** detect_inline_tests, **Then** false — FAIL (RED ✓)
+- [x] TC-03: **Given** file with `#[cfg(test)]` for mock substitution (no mod), **When** detect_inline_tests, **Then** false — FAIL (RED ✓)
+- [x] TC-04: **Given** file with `#[cfg(test)] mod tests;` (external module), **When** detect_inline_tests, **Then** true (regression) — PASS ✓
+- [x] TC-05: **Given** driver.rs w/o Builder, test imports `use myapp::runtime::driver::{Builder}` (direct non-barrel), **When** map_test_files_with_imports, **Then** driver.rs is NOT mapped — FAIL (RED ✓)
+- [x] TC-06: **Given** barrel mod.rs with `pub mod service`, test imports `crate::app::{service_fn}`, service.rs exports `pub fn service_fn`, **When** map_test_files_with_imports, **Then** service.rs IS mapped (regression) — PASS ✓
+
+### WIP
+
+(none)
+
+### DISCOVERED
+
+(none)
+
+### DONE
+
+(none)
+
+## Progress Log
+
+- 2026-03-24 11:19: Cycle doc 作成 (sync-plan)
+- 2026-03-24 11:25: REVIEW (plan) PASS score:15. No blocking issues. Optional: extract sibling-walk helper. Phase completed.
+- 2026-03-24: RED phase completed. 6 tests added to crates/lang-rust/src/observe.rs. TC-01/04/06 PASS (regression), TC-02/03/05 FAIL (RED state confirmed). clippy clean.
+- 2026-03-24: GREEN phase completed. Fix A: detect_inline_tests mod_item sibling check. Fix B: apply_l2_imports file_exports_any_symbol filter. All 147 tests PASS.
+- 2026-03-24: REFACTOR phase completed. Sibling-walk duplication noted (deferred). Verification Gate PASS (1152 tests, clippy 0, fmt clean, BLOCK 0). Phase completed.
+- 2026-03-24: REVIEW (code) PASS score:12. Security PASS(8), Correctness PASS(12). No blocking issues. Phase completed.


### PR DESCRIPTION
## Summary

- **Fix A**: `detect_inline_tests()` now verifies `mod_item` sibling after `#[cfg(test)]`, preventing false detection of conditional compilation helpers
- **Fix B**: `apply_l2_imports()` now filters L2 matches through `file_exports_any_symbol()`, excluding files that don't export the imported symbols
- Expected: 4 FP eliminated (P 92.0% -> ~100%)

## Test plan

- [x] TC-01: `#[cfg(test)] mod tests {}` -> true (regression)
- [x] TC-02: `#[cfg(test)]` helper method (no mod) -> false
- [x] TC-03: `#[cfg(test)]` mock substitution (use stmt) -> false
- [x] TC-04: `#[cfg(test)] mod tests;` (external) -> true (regression)
- [x] TC-05: driver.rs without Builder export -> NOT mapped
- [x] TC-06: service.rs with export -> IS mapped (regression)
- [x] `cargo test` (1152 tests pass)
- [x] `cargo clippy` / `cargo fmt` (clean)
- [x] Self-dogfooding: BLOCK 0

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)