### PR TITLE
docs: Rust final re-audit P=96.0% (#163)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,9 +17,11 @@ Goal: Rust (P=76.7%) と PHP (P=90.0%) の observe precision を改善する。s
 |-------|------|------|-----------------|
 | #161 | ~~Rust L0 barrel self-mapping exclusion~~ | observe precision | **DONE** Rust P 76.7% → 92.0% (+15.3pp) |
 | #163 | ~~Rust 中間 re-audit (50-pair, tokio)~~ | observe validation | **DONE** P=92.0% (46/50). #162 GO判定 |
-| #162 | Rust L2 re-export chain validation + L0 detect_inline_tests 改善 | observe precision | Rust P 92.0% → ~98% (4 FP 排除) |
+| #162 | ~~Rust L2 export filter + L0 mod_item check~~ | observe precision | **DONE** P 92.0% → 96.0% (+4pp). pub(crate) visibility issue 残存 |
+| #163 | ~~Rust final re-audit (50-pair, tokio)~~ | observe validation | **DONE** P=96.0% (48/50). FAIL — pub(crate) visibility fix 必要 |
+| NEW | Rust exported_symbol.scm pub-only filter | observe precision | P 96.0% → ~100% (2 FP: pub(crate) を pub と区別) |
 | #129 | PHP L2 fan-out filter (高頻度utility class抑制) | observe precision | PHP P 90.0% → ~97% (Str, Collection 等の除外) |
-| #163 | Final re-audit (50-pair, tokio + laravel + symfony) | observe validation | ship criteria 最終判定 |
+| NEW | Final re-audit (50-pair, tokio + laravel + symfony) | observe validation | ship criteria 最終判定 |
 
 **Why**: GT audit (#149) で判明した FP パターンは言語固有の構造的問題。Rust は L1 filename matching の曖昧性 (mod.rs, テスト不在ファイル)、PHP は L2 の高頻度utility class (Str, Collection 等) が原因。
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,9 +2,9 @@
 
 ## Current Phase
 
-v0.4.4-dev. #161 L0 barrel exclusion完了、中間re-audit実施。
+v0.4.4-dev. #161 L0 barrel exclusion + #162 L0 mod_item + L2 export filter 完了。Final re-audit P=96.0%。
 
-observe TypeScript: P=100%, R=91% (stable). Python: P=98.2%, R=96.8% (stable). Rust: P=92.0% (experimental, 50-pair re-audit FAIL, +15.3pp from 76.7%). PHP: P=90.0% (experimental, GT audit FAIL). Lint: 17 active rules, 4 languages, same-file helper tracing enabled. Default output: ai-prompt.
+observe TypeScript: P=100%, R=91% (stable). Python: P=98.2%, R=96.8% (stable). Rust: P=96.0% (experimental, 50-pair FAIL, remaining: pub(crate) visibility issue). PHP: P=90.0% (experimental, GT audit FAIL). Lint: 17 active rules, 4 languages, same-file helper tracing enabled. Default output: ai-prompt.
 
 ## Progress
 

--- a/docs/dogfooding-results.md
+++ b/docs/dogfooding-results.md
@@ -1,7 +1,31 @@
 # Dogfooding Results
 
-Latest: 2026-03-24, exspec v0.4.3-dev (post-#161 L0 barrel exclusion + re-audit)
+Latest: 2026-03-24, exspec v0.4.4-dev (post-#161+#162 L0+L2 fixes + final re-audit)
 Initial: 2026-03-09, exspec v0.1.0 (commit 5957cd0)
+
+## Rust Final Re-audit: Post-#162 (50-pair, tokio, 2026-03-24)
+
+Ship criteria: P>=98% (49/50)
+
+| Metric | Value | Target | Result |
+|--------|-------|--------|--------|
+| Precision | **96.0%** (48/50) | >= 98% | **FAIL** |
+| Recall (test file) | ~36.8% (unchanged) | >= 90% | **FAIL** |
+
+FP causes (2/50):
+- L2 `pub(crate)` visibility false match (2): driver.rs ← dump.rs, driver.rs ← shutdown.rs — `pub(crate) struct Handle` matches `exported_symbol.scm` query because tree-sitter `visibility_modifier` includes both `pub` and `pub(crate)`. `file_exports_any_symbol()` returns true for `pub(crate)` items.
+
+### Fix applied vs previous audit
+
+| FP Type | Post-#161 (4 FP) | Post-#162 (2 FP) | Status |
+|---------|-------------------|-------------------|--------|
+| L0 cfg_test helper (source.rs) | 1 | **0** | Fixed by #162 mod_item check |
+| L0 cfg_test mock (open_options.rs) | 1 | 0 (not in sample) | Still exists but `mod mock_open_options;` is a valid mod_item |
+| L2 re-export confusion (driver.rs) | 2 | **2** | NOT fixed — `pub(crate)` matches visibility_modifier |
+
+### Decision: Additional fix needed
+
+P=96.0% < 98%. Root cause: `exported_symbol.scm` does not distinguish `pub` from `pub(crate)`. Fix: refine query to match only `pub` (not `pub(crate)`, `pub(super)`, etc.).
 
 ## Rust Re-audit: Post-#161 (50-pair, tokio, 2026-03-24)
 


### PR DESCRIPTION
## Summary

- Post-#161+#162 Rust observe final re-audit (50-pair, tokio)
- Precision: 92.0% -> **96.0%** (+4pp)
- 2 remaining FPs: `pub(crate) struct Handle` in driver.rs matches export query
- Root cause: `exported_symbol.scm` matches `visibility_modifier` which includes `pub(crate)`
- New issue needed: refine query to pub-only

## Progression

| Phase | Precision | FPs |
|-------|-----------|-----|
| v0.4.3 | 76.7% (23/30) | 7 |
| Post-#161 | 92.0% (46/50) | 4 |
| Post-#162 | **96.0%** (48/50) | 2 |

Ref #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)