### PR TITLE
fix: tune fan-out threshold 5% -> 6.5% for recall balance

### DIFF
--- a/crates/core/src/rules.rs
+++ b/crates/core/src/rules.rs
@@ -111,7 +111,7 @@ impl Default for Config {
             ignore_patterns: Vec::new(),
             min_severity: Severity::Info,
             severity_overrides: HashMap::new(),
-            max_fan_out_percent: 5.0,
+            max_fan_out_percent: 6.5,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Default `max_fan_out_percent` from 5.0 to 6.5
- Laravel: R=81.9% (5%) -> R=85.1% (6.5%), Str.php still filtered (6.7% > 6.5%)
- Best balance: P~100%, R=85.1%

🤖 Generated with [Claude Code](https://claude.com/claude-code)