### PR TITLE
fix: cfg macro text fallback for file_exports_any_symbol + multi-line pub use (#181)

### DIFF
--- a/crates/lang-rust/src/observe.rs
+++ b/crates/lang-rust/src/observe.rs
@@ -409,6 +409,19 @@ impl ObserveExtractor for RustExtractor {
                 }
             }
         }
+        // Fallback: check for pub items inside cfg macros (token_tree is opaque to tree-sitter)
+        // Line-by-line scan to skip comments (avoids matching `// pub struct Foo`)
+        for symbol in symbols {
+            for keyword in &["struct", "fn", "type", "enum", "trait", "const", "static"] {
+                let pattern = format!("pub {keyword} {symbol}");
+                if source.lines().any(|line| {
+                    let trimmed = line.trim();
+                    !trimmed.starts_with("//") && trimmed.contains(&pattern)
+                }) {
+                    return true;
+                }
+            }
+        }
         false
     }
 }
@@ -769,7 +782,8 @@ fn parse_use_path(path: &str, result: &mut HashMap<String, Vec<String>>) {
 /// Extract `pub mod` and `pub use` re-exports from raw text (e.g., inside cfg macro token_tree).
 /// Uses text matching since tree-sitter token_tree content is not structured AST.
 fn extract_re_exports_from_text(text: &str, result: &mut Vec<BarrelReExport>) {
-    for line in text.lines() {
+    let joined = join_multiline_pub_use(text);
+    for line in joined.lines() {
         let trimmed = line.trim();
         // Skip token_tree boundary lines (bare `{` or `}`)
         if trimmed == "{" || trimmed == "}" {
@@ -783,80 +797,93 @@ fn extract_re_exports_from_text(text: &str, result: &mut Vec<BarrelReExport>) {
             .unwrap_or(trimmed)
             .trim();
 
-        // pub mod foo; or pub(crate) mod foo;
-        if (trimmed.starts_with("pub mod ") || trimmed.starts_with("pub(crate) mod "))
-            && trimmed.ends_with(';')
-        {
-            let mod_name = trimmed
-                .trim_start_matches("pub(crate) mod ")
-                .trim_start_matches("pub mod ")
-                .trim_end_matches(';')
-                .trim();
-            if !mod_name.is_empty() && !mod_name.contains(' ') {
-                result.push(BarrelReExport {
-                    symbols: Vec::new(),
-                    from_specifier: format!("./{mod_name}"),
-                    wildcard: true,
-                    namespace_wildcard: false,
-                });
-            }
+        // A single token_tree line may contain multiple statements: "pub mod tcp; pub use ...;"
+        // Split by ';' and process each statement individually.
+        // We do not split inside braces (e.g. pub use mod::{A, B}) — but such content
+        // never contains ';' inside the brace list, so a simple split is safe.
+        let statements: Vec<&str> = trimmed
+            .split(';')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        for stmt in statements {
+            extract_single_re_export_stmt(stmt, result);
         }
+    }
+}
 
-        // pub use module::{A, B}; or pub use module::*;
-        if trimmed.starts_with("pub use ") && trimmed.contains("::") {
-            let use_path = trimmed
-                .trim_start_matches("pub use ")
-                .trim_end_matches(';')
-                .trim();
-            let use_path = use_path.strip_prefix("self::").unwrap_or(use_path);
-            // pub use self::*; -> after strip, use_path = "*"
-            if use_path == "*" {
+fn extract_single_re_export_stmt(trimmed: &str, result: &mut Vec<BarrelReExport>) {
+    // pub mod foo (input is already split by ';', so no trailing semicolon)
+    if trimmed.starts_with("pub mod ") || trimmed.starts_with("pub(crate) mod ") {
+        let mod_name = trimmed
+            .trim_start_matches("pub(crate) mod ")
+            .trim_start_matches("pub mod ")
+            .trim_end_matches(';')
+            .trim();
+        if !mod_name.is_empty() && !mod_name.contains(' ') {
+            result.push(BarrelReExport {
+                symbols: Vec::new(),
+                from_specifier: format!("./{mod_name}"),
+                wildcard: true,
+                namespace_wildcard: false,
+            });
+        }
+    }
+
+    // pub use module::{A, B}; or pub use module::*;
+    if trimmed.starts_with("pub use ") && trimmed.contains("::") {
+        let use_path = trimmed
+            .trim_start_matches("pub use ")
+            .trim_end_matches(';')
+            .trim();
+        let use_path = use_path.strip_prefix("self::").unwrap_or(use_path);
+        // pub use self::*; -> after strip, use_path = "*"
+        if use_path == "*" {
+            result.push(BarrelReExport {
+                symbols: Vec::new(),
+                from_specifier: "./".to_string(),
+                wildcard: true,
+                namespace_wildcard: false,
+            });
+            return;
+        }
+        // Delegate to the same text-based parsing used for tree-sitter nodes
+        if use_path.ends_with("::*") {
+            let module_part = use_path.strip_suffix("::*").unwrap_or("");
+            result.push(BarrelReExport {
+                symbols: Vec::new(),
+                from_specifier: format!("./{}", module_part.replace("::", "/")),
+                wildcard: true,
+                namespace_wildcard: false,
+            });
+        } else if let Some(brace_start) = use_path.find('{') {
+            let module_part = &use_path[..brace_start.saturating_sub(2)];
+            if let Some(brace_end) = use_path.find('}') {
+                let list_content = &use_path[brace_start + 1..brace_end];
+                let symbols: Vec<String> = list_content
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty() && s != "*")
+                    .collect();
                 result.push(BarrelReExport {
-                    symbols: Vec::new(),
-                    from_specifier: "./".to_string(),
-                    wildcard: true,
-                    namespace_wildcard: false,
-                });
-                continue;
-            }
-            // Delegate to the same text-based parsing used for tree-sitter nodes
-            if use_path.ends_with("::*") {
-                let module_part = use_path.strip_suffix("::*").unwrap_or("");
-                result.push(BarrelReExport {
-                    symbols: Vec::new(),
+                    symbols,
                     from_specifier: format!("./{}", module_part.replace("::", "/")),
-                    wildcard: true,
+                    wildcard: false,
                     namespace_wildcard: false,
                 });
-            } else if let Some(brace_start) = use_path.find('{') {
-                let module_part = &use_path[..brace_start.saturating_sub(2)];
-                if let Some(brace_end) = use_path.find('}') {
-                    let list_content = &use_path[brace_start + 1..brace_end];
-                    let symbols: Vec<String> = list_content
-                        .split(',')
-                        .map(|s| s.trim().to_string())
-                        .filter(|s| !s.is_empty() && s != "*")
-                        .collect();
-                    result.push(BarrelReExport {
-                        symbols,
-                        from_specifier: format!("./{}", module_part.replace("::", "/")),
-                        wildcard: false,
-                        namespace_wildcard: false,
-                    });
-                }
-            } else {
-                // pub use module::Symbol;
-                let parts: Vec<&str> = use_path.split("::").collect();
-                if parts.len() >= 2 {
-                    let module_parts = &parts[..parts.len() - 1];
-                    let symbol = parts[parts.len() - 1];
-                    result.push(BarrelReExport {
-                        symbols: vec![symbol.to_string()],
-                        from_specifier: format!("./{}", module_parts.join("/")),
-                        wildcard: false,
-                        namespace_wildcard: false,
-                    });
-                }
+            }
+        } else {
+            // pub use module::Symbol;
+            let parts: Vec<&str> = use_path.split("::").collect();
+            if parts.len() >= 2 {
+                let module_parts = &parts[..parts.len() - 1];
+                let symbol = parts[parts.len() - 1];
+                result.push(BarrelReExport {
+                    symbols: vec![symbol.to_string()],
+                    from_specifier: format!("./{}", module_parts.join("/")),
+                    wildcard: false,
+                    namespace_wildcard: false,
+                });
             }
         }
     }
@@ -1121,6 +1148,50 @@ impl RustExtractor {
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// join_multiline_pub_use
+// ---------------------------------------------------------------------------
+
+/// Join multi-line `pub use module::{\n  ...\n};` into single lines.
+/// Uses brace depth tracking to handle nested use trees like `pub use a::{B::{C, D}, E};`.
+pub(crate) fn join_multiline_pub_use(text: &str) -> String {
+    let mut result = String::new();
+    let mut accumulator: Option<String> = None;
+    let mut brace_depth: usize = 0;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if let Some(ref mut acc) = accumulator {
+            acc.push(' ');
+            acc.push_str(trimmed);
+            for ch in trimmed.chars() {
+                match ch {
+                    '{' => brace_depth += 1,
+                    '}' => brace_depth = brace_depth.saturating_sub(1),
+                    _ => {}
+                }
+            }
+            if brace_depth == 0 {
+                result.push_str(acc);
+                result.push('\n');
+                accumulator = None;
+            }
+        } else if trimmed.starts_with("pub use ") && trimmed.contains('{') && !trimmed.contains('}')
+        {
+            brace_depth = trimmed.chars().filter(|&c| c == '{').count()
+                - trimmed.chars().filter(|&c| c == '}').count();
+            accumulator = Some(trimmed.to_string());
+        } else {
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+    if let Some(acc) = accumulator {
+        result.push_str(&acc);
+        result.push('\n');
+    }
+    result
 }
 
 // ---------------------------------------------------------------------------
@@ -3628,6 +3699,304 @@ cfg_feat! {
              mod_mapping: {:?}, copy_mapping: {:?}",
             mod_mapping.map(|m| &m.test_files),
             copy_mapping.map(|m| &m.test_files)
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-EXPORT-CFG-01: file_exports_any_symbol finds pub struct inside cfg macro
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_export_cfg_01_finds_pub_struct_inside_cfg_macro() {
+        use std::io::Write;
+
+        // Given: temp file with source `cfg_net! { pub struct TcpListener { field: u32 } }`
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            tmp,
+            "cfg_net! {{ pub struct TcpListener {{ field: u32 }} }}\n"
+        )
+        .unwrap();
+        let path = tmp.path();
+
+        // When: file_exports_any_symbol(path, ["TcpListener"]) called
+        let extractor = RustExtractor::new();
+        let symbols = vec!["TcpListener".to_string()];
+        let result = extractor.file_exports_any_symbol(path, &symbols);
+
+        // Then: returns true
+        assert!(
+            result,
+            "Expected file_exports_any_symbol to return true for pub struct inside cfg macro, got false"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-EXPORT-CFG-02: file_exports_any_symbol returns false for non-exported symbol
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_export_cfg_02_returns_false_for_missing_symbol() {
+        use std::io::Write;
+
+        // Given: temp file with source `cfg_net! { pub struct TcpListener { field: u32 } }`
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            tmp,
+            "cfg_net! {{ pub struct TcpListener {{ field: u32 }} }}\n"
+        )
+        .unwrap();
+        let path = tmp.path();
+
+        // When: file_exports_any_symbol(path, ["NotHere"]) called
+        let extractor = RustExtractor::new();
+        let symbols = vec!["NotHere".to_string()];
+        let result = extractor.file_exports_any_symbol(path, &symbols);
+
+        // Then: returns false
+        assert!(
+            !result,
+            "Expected file_exports_any_symbol to return false for symbol not in file, got true"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-EXPORT-CFG-03: file_exports_any_symbol does not match pub(crate)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_export_cfg_03_does_not_match_pub_crate() {
+        use std::io::Write;
+
+        // Given: temp file with source `cfg_net! { pub(crate) struct Internal { field: u32 } }`
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            tmp,
+            "cfg_net! {{ pub(crate) struct Internal {{ field: u32 }} }}\n"
+        )
+        .unwrap();
+        let path = tmp.path();
+
+        // When: file_exports_any_symbol(path, ["Internal"]) called
+        let extractor = RustExtractor::new();
+        let symbols = vec!["Internal".to_string()];
+        let result = extractor.file_exports_any_symbol(path, &symbols);
+
+        // Then: returns false (pub(crate) is not a public export)
+        assert!(
+            !result,
+            "Expected file_exports_any_symbol to return false for pub(crate) struct, got true"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-MULTILINE-USE-01: join_multiline_pub_use joins multi-line pub use
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_multiline_use_01_joins_multiline_pub_use() {
+        // Given: multi-line pub use block
+        let text = "    pub use util::{\n        AsyncReadExt,\n        AsyncWriteExt,\n    };\n";
+
+        // When: join_multiline_pub_use called
+        let result = join_multiline_pub_use(text);
+
+        // Then: result contains "pub use util::{" and "AsyncReadExt" and "}" on one line
+        assert!(
+            result.contains("pub use util::{"),
+            "Expected result to contain 'pub use util::{{', got: {:?}",
+            result
+        );
+        assert!(
+            result.contains("AsyncReadExt"),
+            "Expected result to contain 'AsyncReadExt', got: {:?}",
+            result
+        );
+        assert!(
+            result.contains('}'),
+            "Expected result to contain '}}', got: {:?}",
+            result
+        );
+        // The joined form should appear on a single line (no newline within the pub use statement)
+        let joined_line = result.lines().find(|l| l.contains("pub use util::"));
+        assert!(
+            joined_line.is_some(),
+            "Expected a single line containing 'pub use util::', got: {:?}",
+            result
+        );
+        let joined_line = joined_line.unwrap();
+        assert!(
+            joined_line.contains("AsyncReadExt") && joined_line.contains('}'),
+            "Expected joined line to contain both 'AsyncReadExt' and '}}', got: {:?}",
+            joined_line
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-MULTILINE-USE-02: extract_re_exports_from_text parses joined multi-line pub use
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_multiline_use_02_extract_re_exports_parses_multiline_cfg_pub_use() {
+        // Given: barrel source with multi-line pub use inside cfg macro
+        let source =
+            "cfg_io! {\n    pub use util::{\n        Copy,\n        AsyncReadExt,\n    };\n}\n";
+
+        // When: extract_barrel_re_exports called on mod.rs
+        let extractor = RustExtractor::new();
+        let result = extractor.extract_barrel_re_exports(source, "src/mod.rs");
+
+        // Then: result has entry with from_specifier="./util", symbols contains "Copy" and "AsyncReadExt"
+        let entry = result.iter().find(|e| e.from_specifier == "./util");
+        assert!(
+            entry.is_some(),
+            "Expected entry with from_specifier='./util', got: {:?}",
+            result
+        );
+        let entry = entry.unwrap();
+        assert!(
+            entry.symbols.contains(&"Copy".to_string()),
+            "Expected 'Copy' in symbols, got: {:?}",
+            entry.symbols
+        );
+        assert!(
+            entry.symbols.contains(&"AsyncReadExt".to_string()),
+            "Expected 'AsyncReadExt' in symbols, got: {:?}",
+            entry.symbols
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-L2-CFG-EXPORT-E2E: L2 resolves through cfg-wrapped production file
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_l2_cfg_export_e2e_resolves_through_cfg_wrapped_production_file() {
+        // Given: Cargo project with:
+        //   src/net/mod.rs: `cfg_net! { pub mod tcp; pub use tcp::listener::TcpListener; }`
+        //   src/net/tcp/mod.rs: `pub mod listener;`
+        //   src/net/tcp/listener.rs: `cfg_net! { pub struct TcpListener; }`
+        //   tests/test_net.rs: `use my_crate::net::TcpListener;`
+        let tmp = tempfile::tempdir().unwrap();
+        let src_net_dir = tmp.path().join("src").join("net");
+        let src_tcp_dir = src_net_dir.join("tcp");
+        let src_listener_dir = src_tcp_dir.join("listener");
+        let tests_dir = tmp.path().join("tests");
+        std::fs::create_dir_all(&src_net_dir).unwrap();
+        std::fs::create_dir_all(&src_tcp_dir).unwrap();
+        std::fs::create_dir_all(&src_listener_dir).unwrap();
+        std::fs::create_dir_all(&tests_dir).unwrap();
+
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"my-crate\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+
+        let net_mod_rs = src_net_dir.join("mod.rs");
+        std::fs::write(
+            &net_mod_rs,
+            "cfg_net! { pub mod tcp; pub use tcp::listener::TcpListener; }\n",
+        )
+        .unwrap();
+
+        let tcp_mod_rs = src_tcp_dir.join("mod.rs");
+        std::fs::write(&tcp_mod_rs, "pub mod listener;\n").unwrap();
+
+        let listener_rs = src_tcp_dir.join("listener.rs");
+        std::fs::write(&listener_rs, "cfg_net! { pub struct TcpListener; }\n").unwrap();
+
+        let test_net_rs = tests_dir.join("test_net.rs");
+        let test_source = "use my_crate::net::TcpListener;\n\n#[test]\nfn test_net() {}\n";
+        std::fs::write(&test_net_rs, test_source).unwrap();
+
+        let extractor = RustExtractor::new();
+        let listener_path = listener_rs.to_string_lossy().into_owned();
+        let test_path = test_net_rs.to_string_lossy().into_owned();
+        let production_files = vec![
+            net_mod_rs.to_string_lossy().into_owned(),
+            tcp_mod_rs.to_string_lossy().into_owned(),
+            listener_path.clone(),
+        ];
+        let test_sources: HashMap<String, String> = [(test_path.clone(), test_source.to_string())]
+            .into_iter()
+            .collect();
+
+        // When: map_test_files_with_imports called
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
+
+        // Then: src/net/tcp/listener.rs is mapped to test_net.rs
+        let mapping = result.iter().find(|m| m.production_file == listener_path);
+        assert!(
+            mapping.is_some(),
+            "No mapping found for src/net/tcp/listener.rs"
+        );
+        let mapping = mapping.unwrap();
+        assert!(
+            mapping.test_files.contains(&test_path),
+            "Expected test_net.rs to map to listener.rs through cfg-wrapped barrel (L2), got: {:?}",
+            mapping.test_files
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // RS-L2-CFG-MULTILINE-E2E: L2 resolves through multi-line cfg pub use
+    // -----------------------------------------------------------------------
+    #[test]
+    fn rs_l2_cfg_multiline_e2e_resolves_through_multiline_cfg_pub_use() {
+        // Given: Cargo project with:
+        //   src/io/mod.rs: `cfg_io! {\n    pub use util::{\n        AsyncReadExt,\n        Copy,\n    };\n}`
+        //   src/io/util.rs: `pub trait AsyncReadExt {} pub fn Copy() {}`
+        //   tests/test_io.rs: `use my_crate::io::AsyncReadExt;`
+        let tmp = tempfile::tempdir().unwrap();
+        let src_io_dir = tmp.path().join("src").join("io");
+        let tests_dir = tmp.path().join("tests");
+        std::fs::create_dir_all(&src_io_dir).unwrap();
+        std::fs::create_dir_all(&tests_dir).unwrap();
+
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"my-crate\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+
+        let io_mod_rs = src_io_dir.join("mod.rs");
+        std::fs::write(
+            &io_mod_rs,
+            "cfg_io! {\n    pub use util::{\n        AsyncReadExt,\n        Copy,\n    };\n}\n",
+        )
+        .unwrap();
+
+        let util_rs = src_io_dir.join("util.rs");
+        std::fs::write(&util_rs, "pub trait AsyncReadExt {}\npub fn Copy() {}\n").unwrap();
+
+        let test_io_rs = tests_dir.join("test_io.rs");
+        let test_source = "use my_crate::io::AsyncReadExt;\n\n#[test]\nfn test_io() {}\n";
+        std::fs::write(&test_io_rs, test_source).unwrap();
+
+        let extractor = RustExtractor::new();
+        let util_path = util_rs.to_string_lossy().into_owned();
+        let test_path = test_io_rs.to_string_lossy().into_owned();
+        let production_files = vec![io_mod_rs.to_string_lossy().into_owned(), util_path.clone()];
+        let test_sources: HashMap<String, String> = [(test_path.clone(), test_source.to_string())]
+            .into_iter()
+            .collect();
+
+        // When: map_test_files_with_imports called
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
+
+        // Then: src/io/util.rs mapped to test_io.rs
+        let mapping = result.iter().find(|m| m.production_file == util_path);
+        assert!(mapping.is_some(), "No mapping found for src/io/util.rs");
+        let mapping = mapping.unwrap();
+        assert!(
+            mapping.test_files.contains(&test_path),
+            "Expected test_io.rs to map to util.rs through multi-line cfg pub use (L2), got: {:?}",
+            mapping.test_files
         );
     }
 }

--- a/docs/cycles/20260324_2350_rust-cfg-macro-export-fallback.md
+++ b/docs/cycles/20260324_2350_rust-cfg-macro-export-fallback.md
@@ -1,0 +1,134 @@
+---
+feature: observe: Rust file_exports_any_symbol cfg macro fallback + multi-line pub use
+cycle: 20260324_2350
+phase: DONE
+complexity: trivial
+test_count: 7
+risk_level: low
+codex_session_id: ""
+created: 2026-03-24 23:50
+updated: 2026-03-24 23:50
+---
+
+# #181 observe: Rust file_exports_any_symbol cfg macro fallback + multi-line pub use
+
+## Scope Definition
+
+### In Scope
+- [ ] `file_exports_any_symbol`: text fallback for pub items inside cfg macro token_tree
+- [ ] `join_multiline_pub_use`: helper function to join multi-line pub use blocks
+- [ ] `extract_re_exports_from_text`: use `join_multiline_pub_use` before line-by-line loop
+- [ ] Unit tests (RS-EXPORT-CFG-01~03, RS-MULTILINE-USE-01~02)
+- [ ] Integration tests (RS-L2-CFG-EXPORT-E2E, RS-L2-CFG-MULTILINE-E2E)
+
+### Out of Scope
+- `pub(crate)` visibility handling (not exported as public API)
+- `super::` / `self::` prefix handling (separate issue)
+- Multi-level nested cfg macro resolution (deferred)
+- Other observe recall improvements beyond these 2 function changes
+
+### Files to Change (target: 10 or less)
+- `crates/lang-rust/src/observe.rs` (edit)
+- `crates/lang-rust/tests/observe_tests.rs` (edit — add unit + integration tests)
+
+## Environment
+
+### Scope
+- Layer: Backend (Rust)
+- Plugin: N/A (cargo test + clippy + fmt + self-dogfood)
+- Risk: 20 (PASS)
+
+### Runtime
+- Language: Rust (stable)
+
+### Dependencies (key packages)
+- tree-sitter: workspace version
+- exspec-lang-rust: workspace crate
+
+### Risk Interview (BLOCK only)
+(N/A — Risk 20, PASS)
+
+## Context & Dependencies
+
+### Reference Documents
+- [ROADMAP.md] - v0.4.5 "Now": P1 Rust cfg macro multi-hop barrel resolution
+- [CONSTITUTION.md] - Static AST analysis only, Precision >= 98% / Recall >= 90% ship criteria
+
+### Dependent Features
+- Phase 16 (Rust observe L2): `crates/lang-rust/src/observe.rs`
+- Issue #178: pub use/pub mod extraction from cfg macro blocks (precedent for text fallback approach)
+
+### Related Issues/PRs
+- Issue #181: Rust file_exports_any_symbol misses pub items inside cfg macros
+
+## Test List
+
+### TODO
+- [ ] RS-EXPORT-CFG-01: `file_exports_any_symbol` finds pub struct inside cfg macro
+- [ ] RS-EXPORT-CFG-02: `file_exports_any_symbol` returns false for non-exported symbol
+- [ ] RS-EXPORT-CFG-03: `file_exports_any_symbol` does not match pub(crate)
+- [ ] RS-MULTILINE-USE-01: `join_multiline_pub_use` joins multi-line pub use
+- [ ] RS-MULTILINE-USE-02: `extract_re_exports_from_text` parses joined multi-line pub use
+- [ ] RS-L2-CFG-EXPORT-E2E: L2 resolves through cfg-wrapped production file
+- [ ] RS-L2-CFG-MULTILINE-E2E: L2 resolves through multi-line cfg pub use
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+(none)
+
+## Implementation Notes
+
+### Goal
+Post-#179, Rust observe recall = 62.9% (171/272 in tokio). Two remaining FN buckets: (1) 43 test files import symbols defined inside cfg macros (e.g., `cfg_net! { pub struct TcpListener { ... } }`) — tree-sitter parses cfg macro bodies as opaque `token_tree`, so `file_exports_any_symbol()` returns `false` and L2 filters them out. (2) ~8 more FN from multi-line `pub use util::{\n  ...\n};` in cfg blocks not parsed by the line-by-line loop in `extract_re_exports_from_text`.
+
+### Background
+- `file_exports_any_symbol` uses tree-sitter query to find `pub` items at top level. Items inside cfg macro bodies appear as `token_tree` nodes which are opaque — the query never matches.
+- `extract_re_exports_from_text` processes text line-by-line. Multi-line `pub use module::{...};` spanning multiple lines is not handled.
+
+### Design Approach
+- **Change 1**: After the tree-sitter query loop returns `false`, add text-based fallback. For each requested symbol, check `"pub {keyword} {symbol}"` patterns (struct/fn/type/enum/trait/const/static). Intentionally simple — triggered only when tree-sitter query fails, symbol name must match exactly, and `pub(crate)` won't match.
+- **Change 2**: Add `join_multiline_pub_use(text)` helper that accumulates lines between `pub use module::{` (no closing `}`) and the closing `};`. Call it before the existing line-by-line loop in `extract_re_exports_from_text`.
+
+## Verification
+
+```bash
+cargo test -p exspec-lang-rust
+cargo clippy -- -D warnings
+cargo fmt --check
+cargo run -- --lang rust .
+```
+
+Dogfooding target: tokio observe recall >= 75%
+
+Evidence: (orchestrate が自動記入)
+
+## Progress Log
+
+### 2026-03-24 23:50 - INIT
+- Cycle doc created
+- Plan: /Users/morodomi/.claude/plans/humble-twirling-rabin.md
+- Scope: 2 function changes in observe.rs + 7 tests
+
+### 2026-03-25 - RED
+- 7 tests added: 5 FAILED (expected), 2 PASSED (negative cases)
+- Phase completed
+
+### 2026-03-25 - GREEN
+- 3 fixes: file_exports_any_symbol text fallback, join_multiline_pub_use, extract_re_exports_from_text wiring
+- Additional: extract_single_re_export_stmt split for multi-statement lines
+- 169 passed; 0 failed
+- Phase completed
+
+### 2026-03-25 - REFACTOR
+- Verification Gate: PASS (169 passed, clippy 0, fmt clean, BLOCK 0)
+- Phase completed
+
+### 2026-03-25 - REVIEW
+- Security: PASS (8/100)
+- Correctness: PASS (42/100) -> 3件修正: comment-skip in fallback, brace depth counter, dead code removal
+- Phase completed


### PR DESCRIPTION
## Summary

- `file_exports_any_symbol`: text-based fallback for pub items inside cfg macros (token_tree opaque to tree-sitter), with comment-line skipping
- `join_multiline_pub_use`: joins multi-line `pub use module::{ ... };` with brace depth tracking
- `extract_re_exports_from_text`: semicolon-split for multi-statement token_tree lines

**Impact**: 43 FN in tokio/tests/ caused by cfg-wrapped pub items. Expected recall: 62.9% -> ~78%.

## Test plan

- [x] 7 new unit + integration tests (169 total, all passing)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Self-dogfooding: BLOCK 0
- [ ] Dogfooding: tokio observe recall verification

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)