### PR TITLE
feat: add cross-crate import resolution for Rust integration tests

### DIFF
--- a/crates/lang-rust/src/observe.rs
+++ b/crates/lang-rust/src/observe.rs
@@ -562,6 +562,65 @@ pub fn extract_import_specifiers_with_crate_name(
     result_map.into_iter().collect()
 }
 
+/// Extract import specifiers with support for multiple crate names.
+///
+/// For each `use X::module::Symbol` statement in `source`:
+/// - If X is `crate`, returns `("crate", "module", ["Symbol"])`.
+/// - If X matches any of `crate_names`, returns `(X, "module", ["Symbol"])`.
+/// - Otherwise (e.g. `std::`, `serde::`) the statement is skipped.
+///
+/// Returns `Vec<(matched_crate_name, specifier, symbols)>`.
+pub fn extract_import_specifiers_with_crate_names(
+    source: &str,
+    crate_names: &[&str],
+) -> Vec<(String, String, Vec<String>)> {
+    let mut parser = RustExtractor::parser();
+    let tree = match parser.parse(source, None) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+    let source_bytes = source.as_bytes();
+    let root = tree.root_node();
+    let mut results = Vec::new();
+
+    for i in 0..root.child_count() {
+        let child = root.child(i).unwrap();
+        if child.kind() != "use_declaration" {
+            continue;
+        }
+        let arg = match child.child_by_field_name("argument") {
+            Some(a) => a,
+            None => continue,
+        };
+        let full_text = arg.utf8_text(source_bytes).unwrap_or("");
+
+        // Handle `crate::` prefix
+        if let Some(path_after_crate) = full_text.strip_prefix("crate::") {
+            let mut map: HashMap<String, Vec<String>> = HashMap::new();
+            parse_use_path(path_after_crate, &mut map);
+            for (specifier, symbols) in map {
+                results.push(("crate".to_string(), specifier, symbols));
+            }
+            continue;
+        }
+
+        // Handle each crate name in the list
+        for &name in crate_names {
+            let prefix = format!("{name}::");
+            if let Some(path_after_name) = full_text.strip_prefix(&prefix) {
+                let mut map: HashMap<String, Vec<String>> = HashMap::new();
+                parse_use_path(path_after_name, &mut map);
+                for (specifier, symbols) in map {
+                    results.push((name.to_string(), specifier, symbols));
+                }
+                break; // A use statement can only match one crate name
+            }
+        }
+    }
+
+    results
+}
+
 // ---------------------------------------------------------------------------
 // Workspace support
 // ---------------------------------------------------------------------------
@@ -1070,6 +1129,50 @@ impl RustExtractor {
                     l1_exclusive,
                     &layer1_matched,
                 );
+            }
+
+            // Cross-crate fallback for root integration tests:
+            // Tests not owned by any member (e.g., tests/ at workspace root) may import
+            // workspace member crates directly (e.g., `use clap_builder::...`).
+            // Try resolving these root tests against each member's src/.
+            let root_test_sources: HashMap<String, String> = test_sources
+                .iter()
+                .filter(|(path, _)| {
+                    find_member_for_path(Path::new(path.as_str()), &members).is_none()
+                })
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+
+            if !root_test_sources.is_empty() {
+                for member in &members {
+                    // Try member's own crate name (e.g., `use clap_builder::`)
+                    self.apply_l2_imports(
+                        &root_test_sources,
+                        &member.crate_name,
+                        &member.member_root,
+                        &canonical_root,
+                        &canonical_to_idx,
+                        &mut mappings,
+                        l1_exclusive,
+                        &layer1_matched,
+                    );
+                    // Also try root crate name resolved in member's src/
+                    // (handles `use clap::builder::Arg` → resolves in clap_builder/src/)
+                    if let Some(ref root_name) = crate_name {
+                        if *root_name != member.crate_name {
+                            self.apply_l2_imports(
+                                &root_test_sources,
+                                root_name,
+                                &member.member_root,
+                                &canonical_root,
+                                &canonical_to_idx,
+                                &mut mappings,
+                                l1_exclusive,
+                                &layer1_matched,
+                            );
+                        }
+                    }
+                }
             }
         } else if crate_name.is_none() {
             // Fallback: no [package] and no workspace members; apply L2 with "crate"
@@ -4388,6 +4491,320 @@ cfg_feat! {
                 .contains(&"tests/sync_broadcast.rs".to_string()),
             "Expected tests/sync_broadcast.rs to map to src/sync/broadcast.rs via L1.5, got: {:?}",
             sync_mapping.unwrap().test_files
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // XC-01: cross_crate_extract_root_crate_name
+    // -----------------------------------------------------------------------
+    #[test]
+    fn xc_01_cross_crate_extract_root_crate_name() {
+        // Given: source with `use clap::builder::Arg` and crate_names=["clap", "clap_builder"]
+        let source = "use clap::builder::Arg;\n";
+        let crate_names = ["clap", "clap_builder"];
+
+        // When: extract_import_specifiers_with_crate_names
+        let result = extract_import_specifiers_with_crate_names(source, &crate_names);
+
+        // Then: returns entry with matched_crate_name="clap", specifier="builder", symbols=["Arg"]
+        assert!(
+            !result.is_empty(),
+            "Expected at least one import entry, got empty"
+        );
+        let entry = result
+            .iter()
+            .find(|(crate_n, spec, _)| crate_n == "clap" && spec == "builder");
+        assert!(
+            entry.is_some(),
+            "Expected entry (clap, builder, [Arg]), got: {:?}",
+            result
+        );
+        let (_, _, symbols) = entry.unwrap();
+        assert!(
+            symbols.contains(&"Arg".to_string()),
+            "Expected symbols to contain 'Arg', got: {:?}",
+            symbols
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // XC-02: cross_crate_extract_member_crate_name
+    // -----------------------------------------------------------------------
+    #[test]
+    fn xc_02_cross_crate_extract_member_crate_name() {
+        // Given: source with `use clap_builder::error::ErrorKind`
+        // and crate_names=["clap", "clap_builder"]
+        let source = "use clap_builder::error::ErrorKind;\n";
+        let crate_names = ["clap", "clap_builder"];
+
+        // When: extract_import_specifiers_with_crate_names
+        let result = extract_import_specifiers_with_crate_names(source, &crate_names);
+
+        // Then: returns entry with matched_crate_name="clap_builder", specifier="error",
+        //       symbols=["ErrorKind"]
+        assert!(
+            !result.is_empty(),
+            "Expected at least one import entry, got empty"
+        );
+        let entry = result
+            .iter()
+            .find(|(crate_n, spec, _)| crate_n == "clap_builder" && spec == "error");
+        assert!(
+            entry.is_some(),
+            "Expected entry (clap_builder, error, [ErrorKind]), got: {:?}",
+            result
+        );
+        let (_, _, symbols) = entry.unwrap();
+        assert!(
+            symbols.contains(&"ErrorKind".to_string()),
+            "Expected symbols to contain 'ErrorKind', got: {:?}",
+            symbols
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // XC-03: cross_crate_skips_external
+    // -----------------------------------------------------------------------
+    #[test]
+    fn xc_03_cross_crate_skips_external() {
+        // Given: source with `use std::collections::HashMap` and crate_names=["clap"]
+        let source = "use std::collections::HashMap;\n";
+        let crate_names = ["clap"];
+
+        // When: extract_import_specifiers_with_crate_names
+        let result = extract_import_specifiers_with_crate_names(source, &crate_names);
+
+        // Then: empty (std is not in crate_names)
+        assert!(
+            result.is_empty(),
+            "Expected empty result for std:: import not in crate_names, got: {:?}",
+            result
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // XC-04: cross_crate_crate_prefix_still_works
+    // -----------------------------------------------------------------------
+    #[test]
+    fn xc_04_cross_crate_crate_prefix_still_works() {
+        // Given: source with `use crate::utils` and crate_names=["clap"]
+        let source = "use crate::utils;\n";
+        let crate_names = ["clap"];
+
+        // When: extract_import_specifiers_with_crate_names
+        let result = extract_import_specifiers_with_crate_names(source, &crate_names);
+
+        // Then: returns entry with matched_crate_name="crate", specifier="utils", symbols=[]
+        // (existing behavior for `use crate::` is preserved)
+        assert!(
+            !result.is_empty(),
+            "Expected at least one import entry for `use crate::utils`, got empty"
+        );
+        let entry = result
+            .iter()
+            .find(|(crate_n, spec, _)| crate_n == "crate" && spec == "utils");
+        assert!(
+            entry.is_some(),
+            "Expected entry (crate, utils, []), got: {:?}",
+            result
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // XC-05: cross_crate_root_test_maps_to_root_src
+    // -----------------------------------------------------------------------
+    #[test]
+    fn xc_05_cross_crate_root_test_maps_to_root_src() {
+        // Given: mini workspace:
+        //   Cargo.toml (workspace root + [package] name="my_crate")
+        //   src/builder.rs
+        //   tests/test_builder.rs with `use my_crate::builder::Command;`
+        let tmp = tempfile::tempdir().unwrap();
+        let src_dir = tmp.path().join("src");
+        let tests_dir = tmp.path().join("tests");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        std::fs::create_dir_all(&tests_dir).unwrap();
+
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"my_crate\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+
+        let builder_rs = src_dir.join("builder.rs");
+        std::fs::write(&builder_rs, "pub struct Command;\n").unwrap();
+
+        let test_builder_rs = tests_dir.join("test_builder.rs");
+        let test_source = "use my_crate::builder::Command;\n\n#[test]\nfn test_builder() {}\n";
+        std::fs::write(&test_builder_rs, test_source).unwrap();
+
+        let extractor = RustExtractor::new();
+        let prod_path = builder_rs.to_string_lossy().into_owned();
+        let test_path = test_builder_rs.to_string_lossy().into_owned();
+        let production_files = vec![prod_path.clone()];
+        let test_sources: HashMap<String, String> = [(test_path.clone(), test_source.to_string())]
+            .into_iter()
+            .collect();
+
+        // When: map_test_files_with_imports (cross-crate L2 resolution)
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
+
+        // Then: test_builder.rs maps to src/builder.rs via L2 cross-crate
+        let mapping = result.iter().find(|m| m.production_file == prod_path);
+        assert!(mapping.is_some(), "No mapping found for src/builder.rs");
+        assert!(
+            mapping.unwrap().test_files.contains(&test_path),
+            "Expected test_builder.rs to map to builder.rs via cross-crate L2, got: {:?}",
+            mapping.unwrap().test_files
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // XC-06: cross_crate_root_test_maps_to_member
+    // -----------------------------------------------------------------------
+    #[test]
+    fn xc_06_cross_crate_root_test_maps_to_member() {
+        // Given: mini workspace:
+        //   Cargo.toml (workspace root, no [package])
+        //   member_a/Cargo.toml ([package] name="member_a")
+        //   member_a/src/builder.rs: pub struct Cmd;
+        //   tests/test_builder.rs with `use member_a::builder::Cmd;`
+        //   (tests/ is owned by root, not member_a)
+        let tmp = tempfile::tempdir().unwrap();
+        let member_dir = tmp.path().join("member_a");
+        let member_src = member_dir.join("src");
+        let tests_dir = tmp.path().join("tests");
+        std::fs::create_dir_all(&member_src).unwrap();
+        std::fs::create_dir_all(&tests_dir).unwrap();
+
+        // Workspace root Cargo.toml (no [package], only [workspace])
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"member_a\"]\n",
+        )
+        .unwrap();
+
+        // Member Cargo.toml
+        std::fs::write(
+            member_dir.join("Cargo.toml"),
+            "[package]\nname = \"member_a\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+
+        let builder_rs = member_src.join("builder.rs");
+        std::fs::write(&builder_rs, "pub struct Cmd;\n").unwrap();
+
+        let test_builder_rs = tests_dir.join("test_builder.rs");
+        let test_source = "use member_a::builder::Cmd;\n\n#[test]\nfn test_builder() {}\n";
+        std::fs::write(&test_builder_rs, test_source).unwrap();
+
+        let extractor = RustExtractor::new();
+        let prod_path = builder_rs.to_string_lossy().into_owned();
+        let test_path = test_builder_rs.to_string_lossy().into_owned();
+        let production_files = vec![prod_path.clone()];
+        let test_sources: HashMap<String, String> = [(test_path.clone(), test_source.to_string())]
+            .into_iter()
+            .collect();
+
+        // When: map_test_files_with_imports (cross-crate L2: root test -> member src)
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
+
+        // Then: test_builder.rs (root test) maps to member_a/src/builder.rs via cross-crate L2
+        let mapping = result.iter().find(|m| m.production_file == prod_path);
+        assert!(
+            mapping.is_some(),
+            "No mapping found for member_a/src/builder.rs"
+        );
+        assert!(
+            mapping.unwrap().test_files.contains(&test_path),
+            "Expected root test_builder.rs to map to member_a/src/builder.rs via cross-crate L2, got: {:?}",
+            mapping.unwrap().test_files
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // XC-07: cross_crate_member_test_not_affected
+    //
+    // A member-owned test (member_a/tests/test.rs) is resolved by per-member L2
+    // (using member_a's crate name), NOT by cross-crate fallback from root.
+    // The test verifies that per-member L2 continues to work correctly after
+    // cross-crate fallback is introduced.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn xc_07_cross_crate_member_test_not_affected() {
+        // Given: mini workspace:
+        //   Cargo.toml (workspace root, no [package])
+        //   member_a/Cargo.toml ([package] name="member_a")
+        //   member_a/src/engine.rs: pub struct Engine;
+        //   member_a/tests/test_engine.rs with `use member_a::engine::Engine;`
+        //   (this test is member-owned, not a root integration test)
+        let tmp = tempfile::tempdir().unwrap();
+        let member_dir = tmp.path().join("member_a");
+        let member_src = member_dir.join("src");
+        let member_tests = member_dir.join("tests");
+        std::fs::create_dir_all(&member_src).unwrap();
+        std::fs::create_dir_all(&member_tests).unwrap();
+
+        // Workspace root Cargo.toml (no [package])
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"member_a\"]\n",
+        )
+        .unwrap();
+
+        // Member Cargo.toml
+        std::fs::write(
+            member_dir.join("Cargo.toml"),
+            "[package]\nname = \"member_a\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+
+        let engine_rs = member_src.join("engine.rs");
+        std::fs::write(&engine_rs, "pub struct Engine;\n").unwrap();
+
+        let test_rs = member_tests.join("test_engine.rs");
+        let test_source = "use member_a::engine::Engine;\n\n#[test]\nfn test_engine() {}\n";
+        std::fs::write(&test_rs, test_source).unwrap();
+
+        let extractor = RustExtractor::new();
+        let prod_path = engine_rs.to_string_lossy().into_owned();
+        let test_path = test_rs.to_string_lossy().into_owned();
+        let production_files = vec![prod_path.clone()];
+        let test_sources: HashMap<String, String> = [(test_path.clone(), test_source.to_string())]
+            .into_iter()
+            .collect();
+
+        // When: map_test_files_with_imports
+        // member_a/tests/test_engine.rs is a member-owned test; handled by per-member L2
+        let result = extractor.map_test_files_with_imports(
+            &production_files,
+            &test_sources,
+            tmp.path(),
+            false,
+        );
+
+        // Then: the member-owned test maps correctly via per-member L2
+        // (cross-crate fallback is NOT applied to this test because it is member-owned,
+        //  but normal per-member L2 must still resolve it)
+        let mapping = result.iter().find(|m| m.production_file == prod_path);
+        assert!(
+            mapping.is_some(),
+            "No mapping found for member_a/src/engine.rs"
+        );
+        assert!(
+            mapping.unwrap().test_files.contains(&test_path),
+            "Expected member_a/tests/test_engine.rs to map to member_a/src/engine.rs via per-member L2, got: {:?}",
+            mapping.unwrap().test_files
         );
     }
 }

--- a/docs/cycles/20260325_1116_rust-observe-cross-crate-import-resolution.md
+++ b/docs/cycles/20260325_1116_rust-observe-cross-crate-import-resolution.md
@@ -1,0 +1,163 @@
+---
+feature: rust-observe-cross-crate-import-resolution
+cycle: 20260325_1116
+phase: RED
+complexity: complex
+test_count: 9
+risk_level: medium
+codex_session_id: ""
+created: 2026-03-25 11:16
+updated: 2026-03-25 11:16
+---
+
+# Rust observe: cross-crate import resolution for integration tests
+
+## Scope Definition
+
+### In Scope
+- [ ] `extract_use_declaration()` を複数 crate_name を受け付けるよう拡張
+- [ ] `apply_l2_imports()` を crate_name → member_root mapping 受け取るよう拡張
+- [ ] `map_test_files_with_imports()`: root integration tests に全 member names を渡す cross-crate fallback 追加
+
+### Out of Scope
+- member-owned tests (clap_builder/tests/ 等) への cross-crate fallback 適用 (理由: 不要。per-member L2 で解決済み)
+- L1 マッチングへの影響 (理由: L2 のみの変更)
+
+### Files to Change (target: 10 or less)
+- `crates/lang-rust/src/observe.rs` (edit)
+
+## Environment
+
+### Scope
+- Layer: Backend
+- Plugin: rust
+- Risk: 45/100 (WARN) - L2 import tracing の core logic 変更。既存マッピングに影響する可能性
+
+### Runtime
+- Language: Rust
+
+### Dependencies (key packages)
+- tree-sitter: workspace member
+- lang-rust: workspace crate
+
+### Risk Interview (BLOCK only)
+(N/A - WARN level)
+
+## Context & Dependencies
+
+### Reference Documents
+- [docs/dogfooding-results.md] - Rust observe 現状の P/R 数値 (clap R=14.2%, tokio R=50.8%)
+- [docs/languages/] - Rust observe 設計詳細
+- [ROADMAP.md] - observe ship criteria (P>=98%, R>=90%)
+
+### Dependent Features
+- Rust observe L2 import tracing: `crates/lang-rust/src/observe.rs`
+- Workspace member resolution: `map_test_files_with_imports()`
+
+### Related Issues/PRs
+(none)
+
+## Test List
+
+### TODO
+- [ ] XC-01: Given `use clap::builder::Arg` with crate_names=["clap", "clap_builder"], When extract, Then returns ("clap", "builder", ["Arg"])
+- [ ] XC-02: Given `use clap_builder::error::ErrorKind` with crate_names=["clap", "clap_builder"], When extract, Then returns ("clap_builder", "error", ["ErrorKind"])
+- [ ] XC-03: Given `use std::collections::HashMap` with crate_names=["clap"], When extract, Then skipped (not in crate_names)
+- [ ] XC-04: Given `use crate::utils` with crate_names=["clap"], When extract, Then returns ("crate", "utils", [])
+- [ ] XC-05: Given root integration test `tests/builder/action.rs` with `use clap::Arg` and member clap at scan_root, When L2 with cross-crate resolution, Then test maps to production files in clap/src/
+- [ ] XC-06: Given root integration test with `use clap_builder::builder::Arg` and member clap_builder, When L2, Then test maps to clap_builder/src/builder.rs
+- [ ] XC-07: Given member-owned test (clap_builder/tests/), When cross-crate fallback, Then NOT applied (only root tests)
+- [ ] XC-INT-01: Run observe on clap, verify R improves significantly from 14.2%
+- [ ] XC-INT-02: Run observe on tokio, verify no regression (P=100% maintained)
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+(none)
+
+## Implementation Notes
+
+### Goal
+Rust の workspace 構成において、root crate の integration tests (`tests/`) が workspace member の実装にマッピングされるよう L2 import resolution を拡張する。clap の R=14.2% → 50%+ への改善を目標とする。
+
+### Background
+Rust integration tests は `use crate_name::` (external crate import) を使う。これはRust言語の構造的制約:
+- `tests/` ディレクトリは external crate として扱われる
+- `use crate::` は `src/` 内の unit test でのみ使用可能
+
+Root crate (e.g., `clap`) の `src/lib.rs` は多くの場合 thin barrel で、`pub use clap_builder::*` のように workspace member に re-export する。L2 は `clap/src/` で解決しようとするが、実体は `clap_builder/src/` にある。
+
+### Design Approach
+`extract_use_declaration()` に複数の crate name を渡せるよう拡張する:
+
+```rust
+fn extract_import_specifiers_with_crate_names(
+    source: &str,
+    crate_names: &[&str],  // ["clap", "clap_builder", "clap_derive", ...]
+) -> Vec<(String, String, Vec<String>)>  // (matched_crate_name, specifier, symbols)
+```
+
+各 `use X::module::Symbol` に対し:
+1. X が crate_names のいずれかにマッチ → (X, "module", ["Symbol"]) を返す
+2. `use crate::` → ("crate", "module", ["Symbol"]) (既存動作)
+3. どれにもマッチしない → スキップ (std:: 等)
+
+map_test_files_with_imports() での処理追加:
+```
+// Cross-crate fallback for root integration tests
+root_integration_tests = test_sources not owned by any member
+for member in workspace_members:
+    apply_l2_imports(
+        root_integration_tests,
+        member.crate_name,      // e.g., "clap_builder"
+        member.member_root,     // e.g., "clap/clap_builder"
+        ...
+    )
+```
+
+FP リスク: Root integration test が member A と member B の両方からimportする場合、両方にマッピングされる → これは正しい動作 (secondary targets)。`use std::` 等の外部crateはスキップ (crate_namesに含まれないため)。
+
+## Verification
+
+```bash
+cargo test
+cargo clippy -- -D warnings
+cargo fmt --check
+cargo run -- --lang rust .
+
+# clap dogfooding
+cargo run -- observe --lang rust --format json /tmp/exspec-dogfood/clap > /tmp/clap-post.json
+# 期待: R が 14.2% → 50%+ に改善
+
+# tokio regression check
+cargo run -- observe --lang rust --format json /tmp/exspec-dogfood/tokio > /tmp/tokio-post.json
+python3 scripts/evaluate_observe.py \
+  --observe-json /tmp/tokio-post.json \
+  --ground-truth docs/observe-ground-truth-rust-tokio.md \
+  --scan-root /tmp/exspec-dogfood/tokio
+# 期待: P=100% 維持
+```
+
+Evidence: (orchestrate が自動記入)
+
+## Progress Log
+
+### 2026-03-25 11:16 - INIT
+- Cycle doc created
+- Scope definition ready
+
+---
+
+## Next Steps
+
+1. [Done] INIT <- Current
+2. [Done] PLAN
+3. [Next] RED
+4. [ ] GREEN
+5. [ ] REFACTOR
+6. [ ] REVIEW
+7. [ ] COMMIT


### PR DESCRIPTION
## Summary
- Add cross-crate fallback in `map_test_files_with_imports()` for root integration tests
- Try resolving imports against all workspace member src/ with both member and root crate names
- New `extract_import_specifiers_with_crate_names()` for multi-name import extraction
- 7 unit tests (XC-01~07)

## Results
- clap: R=14.2% -> 20.9% (import strategy: 2 -> 6)
- tokio: P=100%, R=50.8% (no regression)
- 1209 tests passing, clippy 0, BLOCK 0

## Test plan
- [x] 7 XC tests passing
- [x] No regressions (1209 total tests)
- [x] tokio GT: P=100%, R=50.8% unchanged
- [x] Self-dogfooding BLOCK 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)