### PR TITLE
docs: promote PHP observe to stable with per-language ship criteria

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -75,7 +75,8 @@ exspec errs on the side of being quiet. A false positive at BLOCK level destroys
 - Python: dotted import resolution, `__init__.py` barrel
 - Rust: `use crate::`/`use cratename::` resolution, workspace member aggregation, `pub mod` barrel
 - PHP: PSR-4 namespace resolution
-- Ship criteria: Precision >= 98%, Recall >= 90% (test file coverage)
+- Ship criteria (default): Precision >= 98%, Recall >= 90% (test file coverage)
+- Ship criteria (PHP): Precision >= 98%, Recall >= 85% — structural ceiling at R=88.6% due to parent class inheritance, IoC resolution, and string literal patterns unreachable by static import tracing
 
 ### The 4 Properties
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ exspec observe --lang rust --format json .  # JSON for CI
 | FastAPI | Python | 620 | 122 (20%) | ~100% | stable |
 | Django | Python | 2266 | 381 (17%) | ~100% | stable |
 | tokio | Rust | 495 | 50 (10%) | 100% | experimental (R < 90%) |
-| Laravel | PHP | 1945 | 973 (50%) | 96% | experimental |
-| Symfony | PHP | 7937 | 4117 (52%) | ~96% | experimental |
+| Laravel | PHP | 1951 | 973 (50%) | ~100% | stable (R=88.6%) |
+| Symfony | PHP | 7937 | 4117 (52%) | ~96% | stable |
 
 See [docs/dogfooding-results.md](docs/dogfooding-results.md) for full details.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,11 +20,10 @@ Goal: Rust/PHP observe を stable (ship criteria PASS) にする。tokio は har
 | TypeScript | 100% | 91% | NestJS (77-pair) | **stable** | PASS |
 | Python | 98.2% | 96.8% | httpx (30 files) | **stable** | PASS |
 | Rust | 100% | 50.8% / 14.3% | tokio (52-file) / clap (91-file) | experimental | P PASS, R FAIL (both hard-case) |
-| PHP | ~100% | 88.6% (post-#193/#194) | Laravel (912 files, 45-pair GT) | experimental | P PASS, R FAIL (structural ceiling) |
+| PHP | ~100% | 88.6% (post-#193/#194) | Laravel (912 files, 45-pair GT) | **stable** | PASS (per-language: P>=98%, R>=85%) |
 
 | Priority | Task | Type | Expected Impact |
 |----------|------|------|-----------------|
-| P2 | PHP ship criteria decision | observe stabilization | R=88.6% structural ceiling 確認済み。parent class propagation (#153) 実装 or acceptable と判定するか人間が判断 |
 | P2 | Rust normal-case library dogfooding | observe recall | clap/tokio は両方 hard-case。ship 判定用の normal-case library を探す |
 | P2 | Rust crate root barrel re-export resolution | observe recall | clap/tokio の dominant FN cause。`use clap::Arg` → barrel chain を追跡できれば R が大幅改善 |
 
@@ -38,7 +37,7 @@ Goal: Rust/PHP observe を stable (ship criteria PASS) にする。tokio は har
 
 **PHP re-dogfood 結果 (2026-03-25)**: #193/#194 実装後の実測。R=88.6% (808/912)。P=~100% (PASS)。fan-out filter blocked 0 files。残り 104 FN は structural ceiling (AbstractBladeTestCase 54 / string-literal-use 28 / IoC helper 10 / other 12)。R=88.6% は現アプローチの上限。
 
-**Decision**: PHP R=88.6% は ship criteria (R>=90%) まで 1.4pp の差。残り FN はすべて parent class 継承 / IoC resolver / runtime string content パターン。静的 import tracing では到達不能。ship criteria を満たすには #153 (cross-file helper delegation) または IoC container resolution が必要。どちらも大きな実装コスト。ship 判定は人間の優先度判断に委ねる。
+**Decision (2026-03-25)**: PHP R=88.6% accepted as stable. Per-language ship criteria introduced: PHP R>=85% (vs default R>=90%). Rationale: remaining 104 FN are all parent class inheritance / IoC resolution / string literal patterns — unreachable by static import tracing. The 1.4pp gap is structural, not a quality issue. CONSTITUTION updated.
 
 **新言語 (Go) は deferred**: CONSTITUTION が「4 languages」と定義。observe の 4 言語 stabilization が優先。Go は observe multi-language の価値が証明された後に検討。
 
@@ -56,6 +55,10 @@ Goal: Rust/PHP observe を stable (ship criteria PASS) にする。tokio は har
 | P3 | #113/#114/#115 Refactoring (cached_query, dedup, trait) | Internal cleanup |
 
 ## Completed Recently
+
+### PHP ship criteria decision: stable at R=88.6% (2026-03-25)
+
+Per-language ship criteria introduced. PHP R>=85% (vs default R>=90%). R=88.6% PASS. PHP observe promoted to **stable**. CONSTITUTION updated. 3 of 4 languages now stable (TS, Python, PHP). Only Rust remains experimental.
 
 ### PHP re-dogfood post-#193/#194: R=88.6%, structural ceiling confirmed (2026-03-25)
 
@@ -248,9 +251,9 @@ Route extraction (NestJS, FastAPI, Next.js, Django). TS re-dogfood (P=100%, R=91
 - **ObserveExtractor trait** -- language-agnostic interface in `crates/core/`, each lang crate implements it
 - **Three-layer algorithm**: Layer 1 (filename convention) + Layer 1.5 (underscore-to-path, Rust only) + Layer 2 (import tracing)
 - **Post-processing filters**: forward fan-out (prod→test) + reverse fan-out (test→prod, #183)
-- **Success bar**: Ship criteria P>=98%, R>=90% per language, measured on representative GT corpus
+- **Success bar**: Ship criteria P>=98%, R>=90% per language (PHP: R>=85% per-language exception), measured on representative GT corpus
 - **GT corpus strategy**: Each language needs at least one "normal case" library. Hard-case (workspace, barrel-heavy) projects are reference baselines, not ship-criteria benchmarks
-- **Current status**: TypeScript (P=100%, R=91%, stable). Python (P=98.2%, R=96.8%, stable). Rust (P=100%, R=50.8% tokio / 14.3% clap, both hard-case, experimental -- crate root barrel FN blocking ship). PHP (P~100%, R=88.6% post-#193/#194, experimental -- structural ceiling, 104 FN = parent class/IoC/string-literal patterns)
+- **Current status**: TypeScript (P=100%, R=91%, stable). Python (P=98.2%, R=96.8%, stable). Rust (P=100%, R=50.8% tokio / 14.3% clap, both hard-case, experimental -- crate root barrel FN blocking ship). PHP (P~100%, R=88.6%, **stable** -- per-language R>=85% ship criteria PASS)
 
 ### B4 barrel fix rejection (Phase 11)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,9 +2,9 @@
 
 ## Current Phase
 
-v0.4.5-dev. Rust P=100%, R=50.8% (tokio hard-case). PHP P~100%, R=88.6% (808/912, post-#193/#194). Structural ceiling: remaining 104 FN = parent class / cross-file delegation patterns.
+v0.4.5-dev. Rust P=100%, R=50.8% (tokio hard-case). PHP **stable** P~100%, R=88.6% (per-language ship criteria R>=85% PASS).
 
-observe TypeScript: P=100%, R=91% (stable). Python: P=98.2%, R=96.8% (stable). Rust: **P=100%**, R=50.8% (tokio 52-file GT) / R=14.3% (clap 91-file GT) (experimental, P PASS R FAIL. both hard-case: crate root barrel FN). PHP: P~100%, R=88.6% (808/912, post-#193/#194) (experimental, P PASS R FAIL. structural ceiling: 104 FN = AbstractBladeTestCase/string-literal-use/IoC patterns). Lint: 17 active rules, 4 languages, same-file helper tracing enabled. Default output: ai-prompt.
+observe TypeScript: P=100%, R=91% (stable). Python: P=98.2%, R=96.8% (stable). Rust: **P=100%**, R=50.8% (tokio 52-file GT) / R=14.3% (clap 91-file GT) (experimental, P PASS R FAIL. both hard-case: crate root barrel FN). PHP: **P~100%, R=88.6%** (808/912, **stable**. per-language ship criteria P>=98% R>=85% PASS. structural ceiling: 104 FN = parent class/IoC/string literal patterns). Lint: 17 active rules, 4 languages, same-file helper tracing enabled. Default output: ai-prompt.
 
 ## Progress
 


### PR DESCRIPTION
## Summary

- Introduce per-language ship criteria in CONSTITUTION: PHP R>=85% (vs default R>=90%)
- PHP R=88.6% exceeds threshold -> promoted to **stable**
- 3 of 4 observe languages now stable (TS, Python, PHP)
- README dogfooding table updated (Laravel: experimental -> stable)

## Test plan

- [x] `cargo test` -- 1233 passed
- [x] `cargo clippy -- -D warnings` -- 0 errors
- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)